### PR TITLE
REF: stats.unuran: Refactor the UNU.RAN wrapper to avoid memory leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,6 +280,8 @@ scipy/stats/biasedurn.cxx
 scipy/stats/biasedurn.pyx
 scipy/stats/_sobol.c
 scipy/stats/_qmc_cy.cxx
+scipy/stats/_unuran/unuran_wrapper.pyx
+scipy/stats/_unuran/unuran_wrapper.c
 scipy/version.py
 scipy/special/_exprel.c
 scipy/optimize/_group_columns.c

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 	shallow = true
 	active = false
 	ignore = all
+[submodule "scipy/_lib/unuran"]
+	path = scipy/_lib/unuran
+	url = https://github.com/tirthasheshpatel/unuran.git

--- a/benchmarks/benchmarks/stats_sampling.py
+++ b/benchmarks/benchmarks/stats_sampling.py
@@ -1,0 +1,123 @@
+import numpy as np
+from .common import Benchmark, safe_import
+
+with safe_import():
+    from scipy import stats
+with safe_import():
+    from scipy.stats._distr_params import distdiscrete
+
+
+# Beta distribution with a = 2, b = 3
+class contdist1:
+    def pdf(self, x):
+        if 0 < x < 1:
+            return x * (1-x)**2
+        return 0
+    def dpdf(self, x):
+        if 0 < x < 1:
+            return (1-x)**2 - 2*x*(1-x)
+        return 0
+    def cdf(self, x):
+        if x < 0:
+            return 0
+        if x > 1:
+            return 1
+        return stats.beta._cdf(x, 2, 3)
+    def __repr__(self):
+        # asv prints this.
+        return 'beta(2, 3)'
+
+
+# Standard Normal Distribution
+class contdist2:
+    def pdf(self, x):
+        return stats.norm._pdf(x)
+    def dpdf(self, x):
+        return -x * stats.norm._pdf(x)
+    def cdf(self, x):
+        return stats.norm._cdf(x)
+    def __repr__(self):
+        return 'norm(0, 1)'
+
+
+# pdf with piecewise linear function as transformed density with T = -1/sqrt
+# Taken from UNU.RAN test suite (from file t_tdr_ps.c)
+class contdist3:
+    def __init__(self, shift=0.):
+        self.shift = shift
+    def pdf(self, x):
+        x -= self.shift
+        y = 1. / (abs(x) + 1.)
+        return y * y
+    def dpdf(self, x):
+        x -= self.shift
+        y = 1. / (abs(x) + 1.)
+        y = 2. * y * y * y
+        return y if (x < 0.) else -y
+    def cdf(self, x):
+        x -= self.shift
+        if x <= 0.:
+            return 0.5 / (1. - x)
+        return 1. - 0.5 / (1. + x)
+    def __repr__(self):
+        return f'sqrtlinshft({self.shift})'
+
+
+allcontdists = [contdist1(), contdist2(), contdist3(), contdist3(10000.)]
+
+
+class TransformedDensityRejection(Benchmark):
+
+    param_names = ['dist', 'c', 'cpoints']
+
+    params = [allcontdists, [0., -0.5], [10, 20, 30, 50]]
+
+    def setup(self, dist, c, cpoints):
+        self.urng = np.random.default_rng(0xfaad7df1c89e050200dbe258636b3265)
+        with np.testing.suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            try:
+                self.rng = stats.TransformedDensityRejection(dist, c=c,
+                                                             cpoints=cpoints,
+                                                             seed=self.urng)
+            except RuntimeError:
+                # contdist3 is not T-concave for c=0. So, skip such test-cases
+                raise NotImplementedError(f"{dist} not T-concave for c={c}")
+
+    def time_tdr_setup(self, dist, c, cpoints):
+        with np.testing.suppress_warnings() as sup:
+            sup.filter(RuntimeWarning)
+            rng = stats.TransformedDensityRejection(dist, c=c,
+                                                    cpoints=cpoints,
+                                                    seed=self.urng)
+
+    def time_tdr_rvs(self, dist, c, cpoints):
+        rvs = self.rng.rvs(100000)
+
+
+class DiscreteAliasUrn(Benchmark):
+
+    param_names = ['distribution']
+
+    params = [
+        # a subset of discrete distributions with finite domain.
+        [['nhypergeom', (20, 7, 1)],
+         ['hypergeom', (30, 12, 6)],
+         ['nchypergeom_wallenius', (140, 80, 60, 0.5)],
+         ['binom', (5, 0.4)]]
+    ]
+
+    def setup(self, distribution):
+        distname, params = distribution
+        dist = getattr(stats, distname)
+        domain = dist.support(*params)
+        self.urng = np.random.default_rng(0x2fc9eb71cd5120352fa31b7a048aa867)
+        x = np.arange(domain[0], domain[1] + 1)
+        self.pv = dist.pmf(x, *params)
+        self.rng = stats.DiscreteAliasUrn(self.pv, seed=self.urng)
+
+    def time_dau_setup(self, distribution):
+        rng = stats.DiscreteAliasUrn(self.pv, seed=self.urng)
+
+    def time_dau_rvs(self, distribution):
+        rvs = self.rng.rvs(100000)

--- a/doc/source/tutorial/stats.rst
+++ b/doc/source/tutorial/stats.rst
@@ -24,6 +24,7 @@ Note: This documentation is work in progress.
 
    stats/discrete
    stats/continuous
+   stats/sampling
 
 
 Random variables
@@ -199,6 +200,9 @@ seed an internal ``Generator`` object:
 
 For further info, see `NumPy's documentation
 <https://numpy.org/doc/stable/reference/random/index.html>`__.
+
+To learn more about the random number samplers implemented in SciPy, see
+the :ref:`sampling tutorial <non-uniform-random-number-sampling>`
 
 Shifting and scaling
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/tutorial/stats/sampling.rst
+++ b/doc/source/tutorial/stats/sampling.rst
@@ -1,0 +1,199 @@
+.. _non-uniform-random-number-sampling:
+
+=====================================================
+Universal Non-Uniform Random Number Sampling in SciPy
+=====================================================
+
+.. currentmodule:: scipy.stats
+
+SciPy provides an interface to many universal non-uniform random number
+generators to sample random variates from a wide variety of univariate
+continuous and discrete distributions. Implementations of a fast C library
+called `UNU.RAN <http://statmath.wu.ac.at/software/unuran/>`__ are used
+for speed and performance. Please look at
+`UNU.RAN's documentation <http://statmath.wu.ac.at/software/unuran/doc/unuran.html>`__
+for an in-depth explanation of these methods. It is heavily referred to
+for writing this tutorial and the documentation of all the generators.
+
+
+Introduction
+------------
+
+Random variate generation is the small field of research that deals with
+algorithms to generate random variates from various distributions. It is
+common to assume that a uniform random number generator is available.
+This is a program that produces a sequence of independent and identically
+distributed continuous U(0,1) random variates (i.e. uniform random variates
+on the interval (0,1)). Of course, real-world computers can never generate
+ideal random numbers and they cannot produce numbers of arbitrary precision
+but state-of-the-art uniform random number generators come close to this
+aim. Thus random variate generation deals with the problem of transforming
+such a sequence of U(0,1) random numbers into non-uniform random variates.
+These methods are universal and work in a black-box fashion.
+
+Some methods to do that are:
+
+* The Inversion method: When the inverse :math:`F^{-1}` of the cumulative
+  distribution function is known, then random variate generation is easy.
+  We just generate a uniformly U(0,1) distributed random number U and
+  return :math:`X = F^{-1}(U)`. As closed form solutions for the inverse
+  are rarely available, one usually needs to rely on approximations of
+  the inverse. See :class:`~NumericalInverseHermite`.
+* The Rejection Method: The rejection method, often called
+  acceptance-rejection method, has been suggested by John von Neumann in
+  1951 [1]_. It involves computing an upper bound to the PDF (also called the
+  hat function) and using the inversion method to generate a random
+  variate, say Y, from this bound. Then a uniform random number can be
+  drawn between 0 to the value of the upper bound at Y. If this number
+  is less than the PDF at Y, return the sample otherwise reject it. See
+  :class:`~TransformedDensityRejection`.
+* The Ratio-of-Uniforms Method: This is a type of acceptance-rejection
+  method which is uses minimal bounding rectangles to construct the hat
+  function. See :func:`~rvs_ratio_uniforms`.
+* Inversion for Discrete Distributions: The difference compared to the
+  continuous case is that :math:`F` is now a step-function. To realize
+  this in a computer, a search algorithm is used, the simplest of which
+  is *sequential search*. A uniform random number is generated from
+  U(0, 1) and probabilities are summed until the cumulative probability
+  exceeds the uniform random number. The index at which this happens is
+  the required random variate and is returned.
+
+
+More details on these algorithms can be found in the `appendix of the UNU.RAN
+user manual <http://statmath.wu.ac.at/software/unuran/doc/unuran.html#RVG>`__.
+
+
+Basic concepts of the Interface
+-------------------------------
+
+Every generator needs to be set up before one can start sampling from it.
+This can be done by instantiating an object of that class. Most of the
+generators take a distribution object as input which contains the implementation
+of required methods like PDF, CDF, etc. In addition to the distribution
+object, one can also pass parameters used to set up the generator. It is also
+possible to truncate the distributions using a ``domain`` parameter.  All
+generators need a stream of uniform random numbers that are transformed into
+random variates of the given distribution. This is done by passing a ``seed``
+parameter with a NumPy BitGenerator as the uniform random number generator.
+``seed`` can either be a integer, `np.random.Generator`,
+`np.random.BitGenerator`, `np.random.RandomState`, or
+`np.random.SeedSequence`.
+
+.. warning:: Use of NumPy < 1.19.0 is discouraged as it doesn't have a fast
+             Cython API for generating uniform random numbers and might be
+             too slow for practical use.
+
+All the generators have a common ``rvs`` method that can be used to draw
+samples from the given distribution.
+
+An example of this interface is shown below:
+
+    >>> from scipy.stats import TransformedDensityRejection
+    >>> from math import exp
+    >>> 
+    >>> class StandardNormal:
+    ...     def pdf(self, x: float) -> float:
+    ...         # note that the normalization constant isn't required
+    ...         return exp(-0.5 * x*x)
+    ...     def dpdf(self, x: float) -> float:
+    ...         return -x * exp(-0.5 * x*x)
+    ... 
+    >>> dist = StandardNormal()
+    >>> 
+    >>> urng = np.random.default_rng(0x6be00a9336fc82258fe73bfa672d3d52)
+    >>> rng = TransformedDensityRejection(dist, seed=urng)
+
+As shown in the example, we first initialize a distribution object that
+contains an implementation of the methods required by the generator. In
+our case, we use the :class:`~TransformedDensityRejection` method which
+requires a PDF and its derivative w.r.t. x (i.e. the variate). Note that
+the PDF doesn't need to be vectorized. It should accept and return floats.
+
+.. note:: One can also pass the SciPy distributions as arguments but it can
+          be slow due to validations and expensive NumPy operations.
+          Moreover, it doesn't always have all the information required
+          by some generators like derivative of PDF for TDR method. Also,
+          most of the distributions in SciPy provide a ``rvs`` method which
+          can be used instead.
+
+In the above example, we have set up an object of the
+:class:`~TransformedDensityRejection` method to sample from a
+standard normal distribution. Now, we can start sampling from our
+distribution by calling the ``rvs`` method:
+
+    >>> rng.rvs()
+    -0.6853213192313732
+    >>> rng.rvs((5, 3))
+    array([[ 0.24129542,  1.28709556,  0.43244247],
+           [ 0.88977668,  1.22981663, -0.09820373],
+           [ 1.38588147, -1.06629264,  0.54475257],
+           [-0.55153436, -0.67281406,  0.01830143],
+           [ 1.37709649, -1.33036774,  0.62131967]])
+
+.. note:: Please note the difference between the `rvs` method of the
+          distributions present in :mod:`scipy.stats` and the one provided
+          by these generators. In general, the aim of the generation
+          methods implemented in :class:`~rv_continuous` is to provide
+          generators that work reasonably well for common use cases, e.g.
+          to generate small samples using different shape parameters or to
+          generate large samples for a fixed shape parameter. Depending on
+          the goal, specialized methods can lead to a substantial speedup.
+          For example, at the cost of a rather expensive setup step, very
+          fast generation can be achieved for large samples and a fixed
+          shape parameter. Also, even if the same URNG (``seed``) is used,
+          the resulting rvs will be different in general.
+
+We can pass a ``domain`` parameter to truncate the distribution:
+
+    >>> rng = TransformedDensityRejection(dist, domain=(-1, 1), seed=urng)
+    >>> rng.rvs((5, 3))
+    array([[ 0.89612408,  0.03455796,  0.02369241],
+           [ 0.60741875, -0.86184683,  0.49225344],
+           [-0.18349351,  0.55651665, -0.65822471],
+           [ 0.53502455, -0.91848951,  0.72540482],
+           [-0.63404952,  0.28427289,  0.98542246]])
+
+Invalid and bad arguments are handled either by SciPy or by UNU.RAN. The
+latter throws a ``RuntimeError`` that follows a common format:
+
+``RuntimeError: [objid: <object id>] <error code>: <reason> => <type of error>``
+
+where:
+
+* ``<object id>`` is the ID of the object given by UNU.RAN
+* ``<error code>`` is an error code representing a type of error.
+* ``<reason>`` is the reason why the error occurred.
+* ``<type of error>`` is a short description of the type of error.
+
+The ``<reason>`` shows what caused the error. This, by itself, should contain
+enough information to help debug the error. In addition, ``<error id>`` and
+``<type of error>`` can be used to investigate different classes of error in
+UNU.RAN. A complete list of all the error codes and their descriptions can be
+found in the `Section 8.4 of the UNU.RAN user manual
+<http://statmath.wu.ac.at/software/unuran/doc/unuran.html#Errno>`__.
+
+An example of an error generated by UNU.RAN is shown below:
+
+``RuntimeError: [objid: TDR.003] 50 : PDF(x) < 0.! => (generator) (possible) invalid data``
+
+This shows that UNU.RAN failed to initialize an object with ID ``TDR.003``
+because the PDF was < 0. i.e. negative. This falls under the type
+"possible invalid data for the generator" and has error code 50.
+
+Warnings thrown by UNU.RAN also follow the same format.
+
+
+Generators in :mod:`scipy.stats`
+--------------------------------
+.. toctree::
+   :maxdepth: 1
+
+   sampling_tdr
+   sampling_dau
+
+
+References
+~~~~~~~~~~
+
+.. [1] Von Neumann, John. "13. various techniques used in connection with
+       random digits." Appl. Math Ser 12.36-38 (1951): 3.

--- a/doc/source/tutorial/stats/sampling_dau.rst
+++ b/doc/source/tutorial/stats/sampling_dau.rst
@@ -1,0 +1,91 @@
+
+.. _sampling-dau:
+
+Discrete Alias Urn (DAU)
+========================
+
+.. currentmodule:: scipy.stats
+
+* Required: probability vector (PV) or the PMF along with a finite domain
+* Speed:
+
+    * Set-up: slow (linear with the vector-length)
+    * Sampling: very fast 
+
+
+DAU samples from distributions with arbitrary but finite probability vectors
+(PV) of length N. The algorithm is based on an ingenious method by A.J.
+Walker and requires a table of size (at least) N. It needs one random number
+and only one comparison for each generated random variate. The setup time for
+constructing the tables is O(N).
+
+    >>> import numpy as np
+    >>> from scipy.stats import DiscreteAliasUrn
+    >>> 
+    >>> pv = [0.18, 0.02, 0.8]
+    >>> urng = np.random.default_rng(0x8383b295ecbf0874ac910b13adcc85a0)
+    >>> rng = DiscreteAliasUrn(pv, seed=urng)
+    >>> rng.rvs()
+    2
+
+By default, the probability vector is indexed starting at 0. However, this
+can be changed by passing a ``domain`` parameter. When ``domain`` is given
+in combination with the PV, it has the effect of relocating the
+distribution from ``(0, N)`` to ``(domain[0]``, ``domain[0] + N)``.
+``domain[1]`` is ignored in this case.
+
+   >>> rng = DiscreteAliasUrn(pv, domain=(10, 13), seed=urng)
+   >>> rng.rvs()
+   12
+
+The method also works when no probability vector but a PMF is given. However
+then additionally a bounded (finite) domain must also be given.
+
+    >>> class Distribution:
+    ...     def pmf(self, x, c):
+    ...         return x**c
+    ... 
+    >>> dist = Distribution()
+    >>> rng = DiscreteAliasUrn(dist=dist, domain=(1, 10), params=(2, ),
+    ...                        seed=urng)
+    >>> rng.rvs()
+    9
+
+.. note:: As :class:`~DiscreteAliasUrn` expects PMF with signature
+          ``def pmf(x: float, ...) -> float``, it first vectorizes the
+          PMF using ``np.vectorize`` and then evaluates it over all the
+          points in the domain. But if the PMF is already vectorized,
+          it is much faster to just evaluate it at each point in the domain
+          and pass the obtained PV instead along with the domain.
+          For example, ``pmf`` methods of SciPy's discrete distributions
+          are vectorized and a PV can be obtained by doing:
+
+          >>> from scipy.stats import binom, DiscreteAliasUrn
+          >>> dist = binom(10, 0.2)  # distribution object
+          >>> domain = dist.support()  # the domain of your distribution
+          >>> x = np.arange(domain[0], domain[1] + 1)
+          >>> pv = dist.pmf(x)
+          >>> rng = DiscreteAliasUrn(pv, domain=domain)
+
+          Domain is required here to relocate the distribution.
+
+The performance can be slightly influenced by setting the size of the used
+table which can be changed by passing a ``urn_factor`` parameter.
+
+    >>> # use a table twice the length of PV.
+    >>> urn_factor = 2
+    >>> rng = DiscreteAliasUrn(pv, urn_factor=urn_factor, seed=urng)
+    >>> rng.rvs()
+    2
+
+.. note:: It is recommended to keep this parameter under 2.
+
+
+References
+----------
+.. [1] UNU.RAN reference manual, Section 5.8.2,
+       "DAU - (Discrete) Alias-Urn method",
+       http://statmath.wu.ac.at/software/unuran/doc/unuran.html#DAU
+.. [2] A.J. Walker (1977). An efficient method for generating discrete
+       random variables with general distributions, ACM Trans. Math.
+       Software 3, pp. 253-256.

--- a/doc/source/tutorial/stats/sampling_tdr.rst
+++ b/doc/source/tutorial/stats/sampling_tdr.rst
@@ -1,0 +1,187 @@
+
+.. _sampling-tdr:
+
+Transformed Density Rejection (TDR)
+===================================
+
+.. currentmodule:: scipy.stats
+
+* Required: T-concave PDF, dPDF
+* Optional: mode, center
+* Speed:
+
+  * Set-up: slow
+  * Sampling: fast 
+
+
+TDR is an acceptance/rejection method that uses the concavity of a transformed
+density to construct hat function and squeezes automatically. Such PDFs are
+called T-concave. Currently the following transformations are implemented:
+
+.. math::
+
+    c = 0.: T(x) &= \log(x)\\
+    c = -0.5: T(x) &= \frac{1}{\sqrt{x}} \text{ (Default)}
+
+In addition to the PDF, it also requires the derivative of the PDF w.r.t x
+(i.e. the variate). These functions must be present as methods of a python
+object which can then be passed to the generators to instantiate their object.
+
+Three variants of this method are available:
+
+* GW: squeezes between construction points.
+* PS: squeezes proportional to hat function. (Default)
+* IA: same as variant PS but uses a composition method with
+  "immediate acceptance" in the region below the squeeze.
+
+This can be changed by passing a ``variant`` parameter.
+
+An example of using this method is shown below:
+
+    >>> from scipy.stats import TransformedDensityRejection
+    >>> from scipy.stats import norm
+    >>> 
+    >>> class StandardNormal:
+    ...     def pdf(self, x):
+    ...         # note that the normalization constant is not required
+    ...         return np.exp(-0.5 * x*x)
+    ...     def dpdf(self, x):
+    ...         return -x * np.exp(-0.5 * x*x)
+    ... 
+    >>> dist = StandardNormal()
+    >>> 
+    >>> urng = np.random.default_rng(0xbb51a838c8a087854ad3643b2b268d43)
+    >>> rng = TransformedDensityRejection(dist, seed=urng)
+    >>> rng.rvs()
+    0.7771420061983989
+
+In the above example, we have used the TDR method to sample from the standard
+normal distribution. Note that we can drop the normalization constant while
+computing the PDF. This usually helps speed up the sampling stage. Also, note
+that the PDF doesn't need to be vectorized. It should accept and return a
+scalar.
+
+It is also possible to evaluate the inverse of the CDF of the hat distribution
+directly using the ``ppf_hat`` method.
+
+    >>> rng.ppf_hat(0.5)
+    -0.00018050266342362759
+    >>> norm.ppf(0.5)
+    0.0
+    >>> u = np.linspace(0, 1, num=10)
+    >>> rng.ppf_hat(u)
+    array([       -inf, -1.22227372, -0.7656556 , -0.43135731, -0.14002921,
+            0.13966423,  0.43096141,  0.76517113,  1.22185606,         inf])
+    >>> norm.ppf(u)
+    array([       -inf, -1.22064035, -0.76470967, -0.4307273 , -0.1397103 ,
+            0.1397103 ,  0.4307273 ,  0.76470967,  1.22064035,         inf])
+
+Apart from the PPF method, other attributes can be accessed
+to see how well the generator fits the given distribution. These are:
+
+* 'sqhratio': (area below squeeze) / (area below hat) for the generator. It
+  is a number between 0 and 1. Closer to 1 means that the hat and the squeeze
+  functions tightly envelop the distribution and fewer PDF evaluations are
+  required to generate samples. The expected number of evaluations of the
+  density is bounded by ``(1/sqhratio) - 1`` per sample. By default, it is
+  kept above 0.99 but that can be changed by passing a ``max_sqhratio``
+  parameter.
+* 'hat_area': area below the hat for the generator.
+* 'squeeze_area': area below the squeeze for the generator.
+
+    >>> rng.sqhratio
+    0.9947024204884917
+    >>> rng.hat_area
+    2.510253139791547
+    >>> rng.squeeze_area
+    2.4969548741894876
+    >>> rng.sqhratio == rng.squeeze_area / rng.hat_area
+    True
+
+To increase ``sqhratio``, pass ``max_sqhratio``:
+
+    >>> rng = TransformedDensityRejection(dist, max_sqhratio=0.999,
+    ...                                   max_intervals=1000, seed=urng)
+    >>> rng.sqhratio
+    0.999364900465214
+
+Note that we need to increase the ``max_intervals`` parameter when we want
+a higher ``sqhratio``. This is because more construction points are required
+to fit the distribution more tightly.
+
+Let's see how this affects the callbacks to the PDF method of the
+distribution:
+
+    >>> class StandardNormal:
+    ...     def __init__(self):
+    ...         self.callbacks = 0
+    ...     def pdf(self, x):
+    ...         self.callbacks += 1
+    ...         return np.exp(-0.5 * x*x)
+    ...     def dpdf(self, x):
+    ...         return -x * np.exp(-0.5 * x*x)
+    ... 
+    >>> dist1 = StandardNormal()
+    >>> urng = np.random.default_rng(0x7344aca86f1dafd8820be998b639551c)
+    >>> rng = TransformedDensityRejection(dist1, seed=urng)
+    >>> dist1.callbacks  # evaluations during setup
+    139
+    >>> dist1.callbacks = 0  # don't consider evaluations during setup
+    >>> rvs = rng.rvs(100000)
+    >>> dist1.callbacks  # evaluations during sampling
+    551
+    >>> dist2 = StandardNormal()
+    >>> # use the same stream of uniform random numbers
+    >>> urng = np.random.default_rng(0x7344aca86f1dafd8820be998b639551c)
+    >>> rng = TransformedDensityRejection(dist2, max_sqhratio=0.999,
+    ...                                   max_intervals=1000, seed=urng)
+    >>> dist2.callbacks  # evaluations during setup
+    467
+    >>> dist2.callbacks = 0  # don't consider evaluations during setup
+    >>> rvs = rng.rvs(100000)
+    >>> dist2.callbacks  # evaluations during sampling
+    63
+
+As we can see, far fewer PDF evaluations are required during sampling when
+we increase the ``sqhratio``. Also, notice that this comes at the cost of
+increased PDF evaluations during setup.
+
+For densities with modes not close to 0, it is suggested to set either the
+mode or the center of the distribution by passing ``mode`` or ``center``
+parameters. The latter is the approximate location of the mode or the mean
+of the distribution. This location provides some information about the main
+part of the PDF and is used to avoid numerical problems.
+
+    >>> # mode = 0 for our distribution
+    >>> # if exact mode is not available, pass 'center' parameter instead
+    >>> rng = TransformedDensityRejection(dist, mode=0.)
+
+By default, the method uses 30 construction points to construct the hat.
+This can be changed by passing a ``cpoints`` parameter which can either
+be an array of construction points or an integer representing the number
+of construction points to use.
+
+    >>> rng = TransformedDensityRejection(dist, cpoints=[-5, 0, 5])
+
+It is also possible to change the variant of the method used by passing
+a ``variant`` parameter:
+
+    >>> rng = TransformedDensityRejection(dist, variant='ia')
+
+This method accepts many other set-up parameters. See the documentation for
+an exclusive list. More information of the parameters and the method can be
+found in `Section 5.3.16 of the UNU.RAN user manual
+<http://statmath.wu.ac.at/software/unuran/doc/unuran.html#TDR>`__.
+
+
+References
+----------
+
+.. [1] UNU.RAN reference manual, Section 5.3.16,
+       "TDR - Transformed Density Rejection",
+       http://statmath.wu.ac.at/software/unuran/doc/unuran.html#TDR
+.. [2] Hörmann, Wolfgang. "A rejection technique for sampling from
+       T-concave distributions." ACM Transactions on Mathematical
+       Software (TOMS) 21.2 (1995): 182-193
+.. [3] W.R. Gilks and P. Wild (1992). Adaptive rejection sampling for
+       Gibbs sampling, Applied Statistics 41, pp. 337-348.

--- a/mypy.ini
+++ b/mypy.ini
@@ -394,6 +394,9 @@ ignore_errors = True
 [mypy-scipy.stats.tests.test_qmc]
 ignore_errors = True
 
+[mypy-scipy.stats.tests.test_sampling]
+ignore_errors = True
+
 #
 # Files referencing compiled code that needs stubs added.
 #

--- a/scipy/_lib/_unuran_utils.py
+++ b/scipy/_lib/_unuran_utils.py
@@ -1,0 +1,10 @@
+'''Helper functions to get location of UNU.RAN source files.'''
+
+import pathlib
+from typing import Union
+
+
+def _unuran_dir(ret_path: bool = False) -> Union[pathlib.Path, str]:
+    '''Directory where root unuran/ directory lives.'''
+    p = pathlib.Path(__file__).parent / 'unuran'
+    return p if ret_path else str(p)

--- a/scipy/_lib/setup.py
+++ b/scipy/_lib/setup.py
@@ -10,6 +10,14 @@ def check_boost_submodule():
                            "update --init` to fix this.")
 
 
+def check_unuran_submodule():
+    from scipy._lib._unuran_utils import _unuran_dir
+
+    if not os.path.exists(_unuran_dir(ret_path=True) / 'README.md'):
+        raise RuntimeError("Missing the `unuran` submodule! Run `git submodule "
+                           "update --init` to fix this.")
+
+
 def build_clib_pre_build_hook(cmd, ext):
     from scipy._build_utils.compiler_helper import get_cxx_std_flag
     std_flag = get_cxx_std_flag(cmd.compiler)
@@ -23,6 +31,7 @@ def configuration(parent_package='',top_path=None):
     from scipy._lib._boost_utils import _boost_dir
 
     check_boost_submodule()
+    check_unuran_submodule()
 
     config = Configuration('_lib', parent_package, top_path)
     config.add_data_files('tests/*.py')

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -377,6 +377,8 @@ Random variate generation / CDF Inversion
 
    rvs_ratio_uniforms
    NumericalInverseHermite
+   TransformedDensityRejection
+   DiscreteAliasUrn
 
 Circular statistical functions
 ------------------------------
@@ -453,6 +455,7 @@ from ._bootstrap import bootstrap
 from ._entropy import *
 from ._hypotests import *
 from ._rvs_sampling import rvs_ratio_uniforms, NumericalInverseHermite
+from ._unuran import *
 from ._page_trend_test import page_trend_test
 from ._mannwhitneyu import mannwhitneyu
 

--- a/scipy/stats/_generate_pyx.py
+++ b/scipy/stats/_generate_pyx.py
@@ -23,6 +23,20 @@ def make_biasedurn():
         dest.write(contents.format(NPY_OLD=str(bool(isNPY_OLD()))))
 
 
+def make_unuran():
+    '''Substitute True/False values for NPY_OLD Cython build variable.'''
+    import re
+    unuran_base = (
+        pathlib.Path(__file__).parent / '_unuran' / 'unuran_wrapper'
+    ).absolute()
+    with open(unuran_base.with_suffix('.pyx.templ'), 'r') as src:
+        contents = src.read()
+    with open(unuran_base.with_suffix('.pyx'), 'w') as dest:
+        dest.write(re.sub("DEF NPY_OLD = isNPY_OLD",
+                          f"DEF NPY_OLD = {isNPY_OLD()}",
+                          contents))
+
+
 def make_boost():
     # Call code generator inside _boost directory
     code_gen = pathlib.Path(__file__).parent / '_boost/include/code_gen.py'
@@ -31,4 +45,5 @@ def make_boost():
 
 if __name__ == '__main__':
     make_biasedurn()
+    make_unuran()
     make_boost()

--- a/scipy/stats/_unuran/__init__.py
+++ b/scipy/stats/_unuran/__init__.py
@@ -1,0 +1,5 @@
+from .unuran_wrapper import (
+    TransformedDensityRejection,
+    DiscreteAliasUrn,
+    UNURANError
+)

--- a/scipy/stats/_unuran/setup.py
+++ b/scipy/stats/_unuran/setup.py
@@ -1,0 +1,149 @@
+import pathlib
+import os
+
+
+def unuran_pre_build_hook(build_clib, build_info):
+    from scipy._build_utils.compiler_helper import (get_c_std_flag,
+                                                    try_compile, has_flag)
+    c = build_clib.compiler
+    c_flag = get_c_std_flag(c)
+    if c_flag is not None:
+        if "extra_compiler_args" not in build_info:
+            build_info["extra_compiler_args"] = []
+        build_info["extra_compiler_args"].append(c_flag)
+    deps = {"unistd.h": ["HAVE_DECL_GETOPT", "HAVE_UNISTD_H"],
+            "dlfcn.h": ["HAVE_DLFCN_H"],
+            "sys/time.h": ["HAVE_GETTIMEOFDAY", "HAVE_SYS_TIME_H",
+                             "TIME_WITH_SYS_TIME"],
+            "memory.h": ["HAVE_MEMORY_H"],
+            "strings.h": ["HAVE_STRCASECMP", "HAVE_STRINGS_H"],
+            "sys/stat.h": ["HAVE_SYS_STAT_H"],
+            "sys/types.h": ["HAVE_SYS_TYPES_H"]}
+    for dep in deps:
+        has_dep = try_compile(c, code=f"#include <{dep}>\n"
+                                       "int main(int argc, char **argv){}")
+        if has_dep:
+            for macro in deps[dep]:
+                build_info["macros"].append((macro, "1"))
+    if has_flag(c, flag="-lm"):
+        try:
+            build_info["libraries"].append("m")
+        except KeyError:
+            build_info["libraries"] = ["m"]
+
+
+def _get_sources(dirs):
+    sources = []
+    for dir_ in dirs:
+        files = [
+            file for file in os.listdir(dir_) if (not os.path.isdir(file))
+        ]
+        path = [str(dir_ / file) for file in files]
+        sources += [source for source in path if (source.endswith(".c"))]
+    return sources
+
+
+def _get_version(unuran_dir, configure_dot_ac, target_name):
+    configure_dot_ac = unuran_dir / configure_dot_ac
+    with open(configure_dot_ac, "r") as f:
+        s = f.read()
+        start_idx = s.find(target_name)
+        end_idx = s[start_idx:].find(")") + len(s[:start_idx])
+        version = s[start_idx:end_idx].split(",")[1][1:-1]
+    return version
+
+
+def configuration(parent_package="", top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    from scipy._lib._unuran_utils import _unuran_dir
+
+    config = Configuration("_unuran", parent_package, top_path)
+
+    # UNU.RAN info
+    UNURAN_DIR = _unuran_dir(ret_path=True).resolve()
+    UNURAN_VERSION = _get_version(UNURAN_DIR, "unuran/configure.ac",
+                                  "AM_INIT_AUTOMAKE")
+
+    # Define macros assuming we have C99 standard headers
+    DEFINE_MACROS = [
+        ("HAVE_ALARM", "1"),
+        ("HAVE_DECL_ALARM", "1"),
+        ("HAVE_DECL_HUGE_VAL", "1"),
+        ("HAVE_DECL_INFINITY", "1"),
+        ("HAVE_DECL_ISFINITE", "1"),
+        ("HAVE_DECL_ISINF", "1"),
+        ("HAVE_DECL_ISNAN", "1"),
+        ("HAVE_DECL_LOG1P", "1"),
+        ("HAVE_DECL_SIGNAL", "1"),
+        ("HAVE_DECL_SNPRINTF", "1"),
+        ("HAVE_DECL_VSNPRINTF", "1"),
+        ("HAVE_FLOAT_H", "1"),
+        ("HAVE_FLOOR", "1"),
+        ("HAVE_IEEE_COMPARISONS", "1"),
+        ("HAVE_INTTYPES_H", "1"),
+        ("HAVE_LIBM", "1"),
+        ("HAVE_LIMITS_H", "1"),
+        ("HAVE_POW", "1"),
+        ("HAVE_SIGNAL", "1"),
+        ("HAVE_SQRT", "1"),
+        ("HAVE_STDINT_H", "1"),
+        ("HAVE_STDLIB_H", "1"),
+        ("HAVE_STRCHR", "1"),
+        ("HAVE_STRING_H", "1"),
+        ("HAVE_STRTOL", "1"),
+        ("HAVE_STRTOUL", "1"),
+        ("LT_OBJDIR", '".libs/"'),
+        ("PACKAGE", '"unuran"'),
+        ("PACKAGE_BUGREPORT", '"unuran@statmath.wu.ac.at"'),
+        ("PACKAGE_NAME", '"unuran"'),
+        ("PACKAGE_STRING", '"unuran %s"' % UNURAN_VERSION),
+        ("PACKAGE_TARNAME", '"unuran"'),
+        ("PACKAGE_URL", '""'),
+        ("PACKAGE_VERSION", '"%s"' % UNURAN_VERSION),
+        ("STDC_HEADERS", "1"),
+        ("UNUR_ENABLE_INFO", "1"),
+        ("VERSION", '"%s"' % UNURAN_VERSION),
+        ("HAVE_CONFIG_H", "1")
+    ]
+
+    UNURAN_DIRS = [
+        os.path.join("unuran", "src"),
+        os.path.join("unuran", "src", "distr"),
+        os.path.join("unuran", "src", "distributions"),
+        os.path.join("unuran", "src", "methods"),
+        os.path.join("unuran", "src", "parser"),
+        os.path.join("unuran", "src", "specfunct"),
+        os.path.join("unuran", "src", "urng"),
+        os.path.join("unuran", "src", "utils"),
+        os.path.join("unuran", "src", "tests"),
+    ]
+    UNURAN_SOURCE_DIRS = [UNURAN_DIR / dir_ for dir_ in UNURAN_DIRS]
+
+    sources = _get_sources(UNURAN_SOURCE_DIRS[1:])
+
+    ext = config.add_extension(
+        "unuran_wrapper",
+        sources=["unuran_wrapper.c"] + sources,
+        libraries=[],
+        include_dirs=UNURAN_SOURCE_DIRS
+        + [
+            os.path.join(
+                os.path.dirname(__file__), "..", "..", "_lib", "src"
+            )
+        ]
+        + [os.path.dirname(__file__)],
+        language="c",
+        define_macros=DEFINE_MACROS,
+    )
+    ext.pre_build_hook = unuran_pre_build_hook
+
+    config.add_data_files('*.pxd')
+    config.add_data_files('*.pyi')
+
+    return config
+
+
+if __name__ == "__main__":
+    from numpy.distutils.core import setup
+
+    setup(**configuration(top_path="").todict())

--- a/scipy/stats/_unuran/unuran.pxd
+++ b/scipy/stats/_unuran/unuran.pxd
@@ -1,0 +1,1309 @@
+# File automatically generated using autopxd2
+
+from libc.stdio cimport FILE
+
+cdef extern from "unuran.h" nogil:
+
+    cdef struct unur_distr
+
+    ctypedef unur_distr UNUR_DISTR
+
+    cdef struct unur_par
+
+    ctypedef unur_par UNUR_PAR
+
+    cdef struct unur_gen
+
+    ctypedef unur_gen UNUR_GEN
+
+    cdef struct unur_urng
+
+    ctypedef unur_urng UNUR_URNG
+
+    ctypedef double UNUR_FUNCT_CONT(double x, unur_distr* distr)
+
+    ctypedef double UNUR_FUNCT_DISCR(int x, unur_distr* distr)
+
+    ctypedef int UNUR_IFUNCT_DISCR(double x, unur_distr* distr)
+
+    ctypedef double UNUR_FUNCT_CVEC(double* x, unur_distr* distr)
+
+    ctypedef int UNUR_VFUNCT_CVEC(double* result, double* x, unur_distr* distr)
+
+    ctypedef double UNUR_FUNCTD_CVEC(double* x, int coord, unur_distr* distr)
+
+    cdef struct unur_slist
+
+    ctypedef void UNUR_ERROR_HANDLER(char* objid, char* file, int line, char* errortype, int unur_errno, char* reason)
+
+    UNUR_URNG* unur_get_default_urng()
+
+    UNUR_URNG* unur_set_default_urng(UNUR_URNG* urng_new)
+
+    UNUR_URNG* unur_set_default_urng_aux(UNUR_URNG* urng_new)
+
+    UNUR_URNG* unur_get_default_urng_aux()
+
+    int unur_set_urng(UNUR_PAR* parameters, UNUR_URNG* urng)
+
+    UNUR_URNG* unur_chg_urng(UNUR_GEN* generator, UNUR_URNG* urng)
+
+    UNUR_URNG* unur_get_urng(UNUR_GEN* generator)
+
+    int unur_set_urng_aux(UNUR_PAR* parameters, UNUR_URNG* urng_aux)
+
+    int unur_use_urng_aux_default(UNUR_PAR* parameters)
+
+    int unur_chgto_urng_aux_default(UNUR_GEN* generator)
+
+    UNUR_URNG* unur_chg_urng_aux(UNUR_GEN* generator, UNUR_URNG* urng_aux)
+
+    UNUR_URNG* unur_get_urng_aux(UNUR_GEN* generator)
+
+    double unur_urng_sample(UNUR_URNG* urng)
+
+    double unur_sample_urng(UNUR_GEN* gen)
+
+    int unur_urng_sample_array(UNUR_URNG* urng, double* X, int dim)
+
+    int unur_urng_reset(UNUR_URNG* urng)
+
+    int unur_urng_sync(UNUR_URNG* urng)
+
+    int unur_urng_seed(UNUR_URNG* urng, unsigned long seed)
+
+    int unur_urng_anti(UNUR_URNG* urng, int anti)
+
+    int unur_urng_nextsub(UNUR_URNG* urng)
+
+    int unur_urng_resetsub(UNUR_URNG* urng)
+
+    int unur_gen_sync(UNUR_GEN* generator)
+
+    int unur_gen_seed(UNUR_GEN* generator, unsigned long seed)
+
+    int unur_gen_anti(UNUR_GEN* generator, int anti)
+
+    int unur_gen_reset(UNUR_GEN* generator)
+
+    int unur_gen_nextsub(UNUR_GEN* generator)
+
+    int unur_gen_resetsub(UNUR_GEN* generator)
+
+    ctypedef double (*_unur_urng_new_sampleunif_ft)(void* state)
+
+    UNUR_URNG* unur_urng_new(_unur_urng_new_sampleunif_ft sampleunif, void* state)
+
+    void unur_urng_free(UNUR_URNG* urng)
+
+    ctypedef unsigned int (*_unur_urng_set_sample_array_samplearray_ft)(void* state, double* X, int dim)
+
+    int unur_urng_set_sample_array(UNUR_URNG* urng, _unur_urng_set_sample_array_samplearray_ft samplearray)
+
+    ctypedef void (*_unur_urng_set_sync_sync_ft)(void* state)
+
+    int unur_urng_set_sync(UNUR_URNG* urng, _unur_urng_set_sync_sync_ft sync)
+
+    ctypedef void (*_unur_urng_set_seed_setseed_ft)(void* state, unsigned long seed)
+
+    int unur_urng_set_seed(UNUR_URNG* urng, _unur_urng_set_seed_setseed_ft setseed)
+
+    ctypedef void (*_unur_urng_set_anti_setanti_ft)(void* state, int anti)
+
+    int unur_urng_set_anti(UNUR_URNG* urng, _unur_urng_set_anti_setanti_ft setanti)
+
+    ctypedef void (*_unur_urng_set_reset_reset_ft)(void* state)
+
+    int unur_urng_set_reset(UNUR_URNG* urng, _unur_urng_set_reset_reset_ft reset)
+
+    ctypedef void (*_unur_urng_set_nextsub_nextsub_ft)(void* state)
+
+    int unur_urng_set_nextsub(UNUR_URNG* urng, _unur_urng_set_nextsub_nextsub_ft nextsub)
+
+    ctypedef void (*_unur_urng_set_resetsub_resetsub_ft)(void* state)
+
+    int unur_urng_set_resetsub(UNUR_URNG* urng, _unur_urng_set_resetsub_resetsub_ft resetsub)
+
+    ctypedef void (*_unur_urng_set_delete_fpdelete_ft)(void* state)
+
+    int unur_urng_set_delete(UNUR_URNG* urng, _unur_urng_set_delete_fpdelete_ft fpdelete)
+
+    cdef enum:
+        UNUR_DISTR_CONT
+        UNUR_DISTR_CEMP
+        UNUR_DISTR_CVEC
+        UNUR_DISTR_CVEMP
+        UNUR_DISTR_MATR
+        UNUR_DISTR_DISCR
+
+    void unur_distr_free(UNUR_DISTR* distribution)
+
+    int unur_distr_set_name(UNUR_DISTR* distribution, char* name)
+
+    char* unur_distr_get_name(UNUR_DISTR* distribution)
+
+    int unur_distr_get_dim(UNUR_DISTR* distribution)
+
+    unsigned int unur_distr_get_type(UNUR_DISTR* distribution)
+
+    int unur_distr_is_cont(UNUR_DISTR* distribution)
+
+    int unur_distr_is_cvec(UNUR_DISTR* distribution)
+
+    int unur_distr_is_cemp(UNUR_DISTR* distribution)
+
+    int unur_distr_is_cvemp(UNUR_DISTR* distribution)
+
+    int unur_distr_is_discr(UNUR_DISTR* distribution)
+
+    int unur_distr_is_matr(UNUR_DISTR* distribution)
+
+    int unur_distr_set_extobj(UNUR_DISTR* distribution, void* extobj)
+
+    void* unur_distr_get_extobj(UNUR_DISTR* distribution)
+
+    UNUR_DISTR* unur_distr_clone(UNUR_DISTR* distr)
+
+    UNUR_DISTR* unur_distr_cemp_new()
+
+    int unur_distr_cemp_set_data(UNUR_DISTR* distribution, double* sample, int n_sample)
+
+    int unur_distr_cemp_read_data(UNUR_DISTR* distribution, char* filename)
+
+    int unur_distr_cemp_get_data(UNUR_DISTR* distribution, double** sample)
+
+    int unur_distr_cemp_set_hist(UNUR_DISTR* distribution, double* prob, int n_prob, double xmin, double xmax)
+
+    int unur_distr_cemp_set_hist_prob(UNUR_DISTR* distribution, double* prob, int n_prob)
+
+    int unur_distr_cemp_set_hist_domain(UNUR_DISTR* distribution, double xmin, double xmax)
+
+    int unur_distr_cemp_set_hist_bins(UNUR_DISTR* distribution, double* bins, int n_bins)
+
+    UNUR_DISTR* unur_distr_cont_new()
+
+    int unur_distr_cont_set_pdf(UNUR_DISTR* distribution, UNUR_FUNCT_CONT* pdf)
+
+    int unur_distr_cont_set_dpdf(UNUR_DISTR* distribution, UNUR_FUNCT_CONT* dpdf)
+
+    int unur_distr_cont_set_cdf(UNUR_DISTR* distribution, UNUR_FUNCT_CONT* cdf)
+
+    int unur_distr_cont_set_invcdf(UNUR_DISTR* distribution, UNUR_FUNCT_CONT* invcdf)
+
+    UNUR_FUNCT_CONT* unur_distr_cont_get_pdf(UNUR_DISTR* distribution)
+
+    UNUR_FUNCT_CONT* unur_distr_cont_get_dpdf(UNUR_DISTR* distribution)
+
+    UNUR_FUNCT_CONT* unur_distr_cont_get_cdf(UNUR_DISTR* distribution)
+
+    UNUR_FUNCT_CONT* unur_distr_cont_get_invcdf(UNUR_DISTR* distribution)
+
+    double unur_distr_cont_eval_pdf(double x, UNUR_DISTR* distribution)
+
+    double unur_distr_cont_eval_dpdf(double x, UNUR_DISTR* distribution)
+
+    double unur_distr_cont_eval_cdf(double x, UNUR_DISTR* distribution)
+
+    double unur_distr_cont_eval_invcdf(double u, UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_logpdf(UNUR_DISTR* distribution, UNUR_FUNCT_CONT* logpdf)
+
+    int unur_distr_cont_set_dlogpdf(UNUR_DISTR* distribution, UNUR_FUNCT_CONT* dlogpdf)
+
+    int unur_distr_cont_set_logcdf(UNUR_DISTR* distribution, UNUR_FUNCT_CONT* logcdf)
+
+    UNUR_FUNCT_CONT* unur_distr_cont_get_logpdf(UNUR_DISTR* distribution)
+
+    UNUR_FUNCT_CONT* unur_distr_cont_get_dlogpdf(UNUR_DISTR* distribution)
+
+    UNUR_FUNCT_CONT* unur_distr_cont_get_logcdf(UNUR_DISTR* distribution)
+
+    double unur_distr_cont_eval_logpdf(double x, UNUR_DISTR* distribution)
+
+    double unur_distr_cont_eval_dlogpdf(double x, UNUR_DISTR* distribution)
+
+    double unur_distr_cont_eval_logcdf(double x, UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_pdfstr(UNUR_DISTR* distribution, char* pdfstr)
+
+    int unur_distr_cont_set_cdfstr(UNUR_DISTR* distribution, char* cdfstr)
+
+    char* unur_distr_cont_get_pdfstr(UNUR_DISTR* distribution)
+
+    char* unur_distr_cont_get_dpdfstr(UNUR_DISTR* distribution)
+
+    char* unur_distr_cont_get_cdfstr(UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_pdfparams(UNUR_DISTR* distribution, double* params, int n_params)
+
+    int unur_distr_cont_get_pdfparams(UNUR_DISTR* distribution, double** params)
+
+    int unur_distr_cont_set_pdfparams_vec(UNUR_DISTR* distribution, int par, double* param_vec, int n_param_vec)
+
+    int unur_distr_cont_get_pdfparams_vec(UNUR_DISTR* distribution, int par, double** param_vecs)
+
+    int unur_distr_cont_set_logpdfstr(UNUR_DISTR* distribution, char* logpdfstr)
+
+    char* unur_distr_cont_get_logpdfstr(UNUR_DISTR* distribution)
+
+    char* unur_distr_cont_get_dlogpdfstr(UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_logcdfstr(UNUR_DISTR* distribution, char* logcdfstr)
+
+    char* unur_distr_cont_get_logcdfstr(UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_domain(UNUR_DISTR* distribution, double left, double right)
+
+    int unur_distr_cont_get_domain(UNUR_DISTR* distribution, double* left, double* right)
+
+    int unur_distr_cont_get_truncated(UNUR_DISTR* distribution, double* left, double* right)
+
+    int unur_distr_cont_set_hr(UNUR_DISTR* distribution, UNUR_FUNCT_CONT* hazard)
+
+    UNUR_FUNCT_CONT* unur_distr_cont_get_hr(UNUR_DISTR* distribution)
+
+    double unur_distr_cont_eval_hr(double x, UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_hrstr(UNUR_DISTR* distribution, char* hrstr)
+
+    char* unur_distr_cont_get_hrstr(UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_mode(UNUR_DISTR* distribution, double mode)
+
+    int unur_distr_cont_upd_mode(UNUR_DISTR* distribution)
+
+    double unur_distr_cont_get_mode(UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_center(UNUR_DISTR* distribution, double center)
+
+    double unur_distr_cont_get_center(UNUR_DISTR* distribution)
+
+    int unur_distr_cont_set_pdfarea(UNUR_DISTR* distribution, double area)
+
+    int unur_distr_cont_upd_pdfarea(UNUR_DISTR* distribution)
+
+    double unur_distr_cont_get_pdfarea(UNUR_DISTR* distribution)
+
+    UNUR_DISTR* unur_distr_cxtrans_new(UNUR_DISTR* distribution)
+
+    UNUR_DISTR* unur_distr_cxtrans_get_distribution(UNUR_DISTR* distribution)
+
+    int unur_distr_cxtrans_set_alpha(UNUR_DISTR* distribution, double alpha)
+
+    int unur_distr_cxtrans_set_rescale(UNUR_DISTR* distribution, double mu, double sigma)
+
+    double unur_distr_cxtrans_get_alpha(UNUR_DISTR* distribution)
+
+    double unur_distr_cxtrans_get_mu(UNUR_DISTR* distribution)
+
+    double unur_distr_cxtrans_get_sigma(UNUR_DISTR* distribution)
+
+    int unur_distr_cxtrans_set_logpdfpole(UNUR_DISTR* distribution, double logpdfpole, double dlogpdfpole)
+
+    int unur_distr_cxtrans_set_domain(UNUR_DISTR* distribution, double left, double right)
+
+    UNUR_DISTR* unur_distr_corder_new(UNUR_DISTR* distribution, int n, int k)
+
+    UNUR_DISTR* unur_distr_corder_get_distribution(UNUR_DISTR* distribution)
+
+    int unur_distr_corder_set_rank(UNUR_DISTR* distribution, int n, int k)
+
+    int unur_distr_corder_get_rank(UNUR_DISTR* distribution, int* n, int* k)
+
+    UNUR_DISTR* unur_distr_cvec_new(int dim)
+
+    int unur_distr_cvec_set_pdf(UNUR_DISTR* distribution, UNUR_FUNCT_CVEC* pdf)
+
+    int unur_distr_cvec_set_dpdf(UNUR_DISTR* distribution, UNUR_VFUNCT_CVEC* dpdf)
+
+    int unur_distr_cvec_set_pdpdf(UNUR_DISTR* distribution, UNUR_FUNCTD_CVEC* pdpdf)
+
+    UNUR_FUNCT_CVEC* unur_distr_cvec_get_pdf(UNUR_DISTR* distribution)
+
+    UNUR_VFUNCT_CVEC* unur_distr_cvec_get_dpdf(UNUR_DISTR* distribution)
+
+    UNUR_FUNCTD_CVEC* unur_distr_cvec_get_pdpdf(UNUR_DISTR* distribution)
+
+    double unur_distr_cvec_eval_pdf(double* x, UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_eval_dpdf(double* result, double* x, UNUR_DISTR* distribution)
+
+    double unur_distr_cvec_eval_pdpdf(double* x, int coord, UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_set_logpdf(UNUR_DISTR* distribution, UNUR_FUNCT_CVEC* logpdf)
+
+    int unur_distr_cvec_set_dlogpdf(UNUR_DISTR* distribution, UNUR_VFUNCT_CVEC* dlogpdf)
+
+    int unur_distr_cvec_set_pdlogpdf(UNUR_DISTR* distribution, UNUR_FUNCTD_CVEC* pdlogpdf)
+
+    UNUR_FUNCT_CVEC* unur_distr_cvec_get_logpdf(UNUR_DISTR* distribution)
+
+    UNUR_VFUNCT_CVEC* unur_distr_cvec_get_dlogpdf(UNUR_DISTR* distribution)
+
+    UNUR_FUNCTD_CVEC* unur_distr_cvec_get_pdlogpdf(UNUR_DISTR* distribution)
+
+    double unur_distr_cvec_eval_logpdf(double* x, UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_eval_dlogpdf(double* result, double* x, UNUR_DISTR* distribution)
+
+    double unur_distr_cvec_eval_pdlogpdf(double* x, int coord, UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_set_mean(UNUR_DISTR* distribution, double* mean)
+
+    double* unur_distr_cvec_get_mean(UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_set_covar(UNUR_DISTR* distribution, double* covar)
+
+    int unur_distr_cvec_set_covar_inv(UNUR_DISTR* distribution, double* covar_inv)
+
+    double* unur_distr_cvec_get_covar(UNUR_DISTR* distribution)
+
+    double* unur_distr_cvec_get_cholesky(UNUR_DISTR* distribution)
+
+    double* unur_distr_cvec_get_covar_inv(UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_set_rankcorr(UNUR_DISTR* distribution, double* rankcorr)
+
+    double* unur_distr_cvec_get_rankcorr(UNUR_DISTR* distribution)
+
+    double* unur_distr_cvec_get_rk_cholesky(UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_set_marginals(UNUR_DISTR* distribution, UNUR_DISTR* marginal)
+
+    int unur_distr_cvec_set_marginal_array(UNUR_DISTR* distribution, UNUR_DISTR** marginals)
+
+    int unur_distr_cvec_set_marginal_list(UNUR_DISTR* distribution)
+
+    UNUR_DISTR* unur_distr_cvec_get_marginal(UNUR_DISTR* distribution, int n)
+
+    int unur_distr_cvec_set_pdfparams(UNUR_DISTR* distribution, double* params, int n_params)
+
+    int unur_distr_cvec_get_pdfparams(UNUR_DISTR* distribution, double** params)
+
+    int unur_distr_cvec_set_pdfparams_vec(UNUR_DISTR* distribution, int par, double* param_vec, int n_params)
+
+    int unur_distr_cvec_get_pdfparams_vec(UNUR_DISTR* distribution, int par, double** param_vecs)
+
+    int unur_distr_cvec_set_domain_rect(UNUR_DISTR* distribution, double* lowerleft, double* upperright)
+
+    int unur_distr_cvec_is_indomain(double* x, UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_set_mode(UNUR_DISTR* distribution, double* mode)
+
+    int unur_distr_cvec_upd_mode(UNUR_DISTR* distribution)
+
+    double* unur_distr_cvec_get_mode(UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_set_center(UNUR_DISTR* distribution, double* center)
+
+    double* unur_distr_cvec_get_center(UNUR_DISTR* distribution)
+
+    int unur_distr_cvec_set_pdfvol(UNUR_DISTR* distribution, double volume)
+
+    int unur_distr_cvec_upd_pdfvol(UNUR_DISTR* distribution)
+
+    double unur_distr_cvec_get_pdfvol(UNUR_DISTR* distribution)
+
+    UNUR_DISTR* unur_distr_condi_new(UNUR_DISTR* distribution, double* pos, double* dir, int k)
+
+    int unur_distr_condi_set_condition(unur_distr* distribution, double* pos, double* dir, int k)
+
+    int unur_distr_condi_get_condition(unur_distr* distribution, double** pos, double** dir, int* k)
+
+    UNUR_DISTR* unur_distr_condi_get_distribution(UNUR_DISTR* distribution)
+
+    UNUR_DISTR* unur_distr_cvemp_new(int dim)
+
+    int unur_distr_cvemp_set_data(UNUR_DISTR* distribution, double* sample, int n_sample)
+
+    int unur_distr_cvemp_read_data(UNUR_DISTR* distribution, char* filename)
+
+    int unur_distr_cvemp_get_data(UNUR_DISTR* distribution, double** sample)
+
+    UNUR_DISTR* unur_distr_discr_new()
+
+    int unur_distr_discr_set_pv(UNUR_DISTR* distribution, double* pv, int n_pv)
+
+    int unur_distr_discr_make_pv(UNUR_DISTR* distribution)
+
+    int unur_distr_discr_get_pv(UNUR_DISTR* distribution, double** pv)
+
+    int unur_distr_discr_set_pmf(UNUR_DISTR* distribution, UNUR_FUNCT_DISCR* pmf)
+
+    int unur_distr_discr_set_cdf(UNUR_DISTR* distribution, UNUR_FUNCT_DISCR* cdf)
+
+    int unur_distr_discr_set_invcdf(UNUR_DISTR* distribution, UNUR_IFUNCT_DISCR* invcdf)
+
+    UNUR_FUNCT_DISCR* unur_distr_discr_get_pmf(UNUR_DISTR* distribution)
+
+    UNUR_FUNCT_DISCR* unur_distr_discr_get_cdf(UNUR_DISTR* distribution)
+
+    UNUR_IFUNCT_DISCR* unur_distr_discr_get_invcdf(UNUR_DISTR* distribution)
+
+    double unur_distr_discr_eval_pv(int k, UNUR_DISTR* distribution)
+
+    double unur_distr_discr_eval_pmf(int k, UNUR_DISTR* distribution)
+
+    double unur_distr_discr_eval_cdf(int k, UNUR_DISTR* distribution)
+
+    int unur_distr_discr_eval_invcdf(double u, UNUR_DISTR* distribution)
+
+    int unur_distr_discr_set_pmfstr(UNUR_DISTR* distribution, char* pmfstr)
+
+    int unur_distr_discr_set_cdfstr(UNUR_DISTR* distribution, char* cdfstr)
+
+    char* unur_distr_discr_get_pmfstr(UNUR_DISTR* distribution)
+
+    char* unur_distr_discr_get_cdfstr(UNUR_DISTR* distribution)
+
+    int unur_distr_discr_set_pmfparams(UNUR_DISTR* distribution, double* params, int n_params)
+
+    int unur_distr_discr_get_pmfparams(UNUR_DISTR* distribution, double** params)
+
+    int unur_distr_discr_set_domain(UNUR_DISTR* distribution, int left, int right)
+
+    int unur_distr_discr_get_domain(UNUR_DISTR* distribution, int* left, int* right)
+
+    int unur_distr_discr_set_mode(UNUR_DISTR* distribution, int mode)
+
+    int unur_distr_discr_upd_mode(UNUR_DISTR* distribution)
+
+    int unur_distr_discr_get_mode(UNUR_DISTR* distribution)
+
+    int unur_distr_discr_set_pmfsum(UNUR_DISTR* distribution, double sum)
+
+    int unur_distr_discr_upd_pmfsum(UNUR_DISTR* distribution)
+
+    double unur_distr_discr_get_pmfsum(UNUR_DISTR* distribution)
+
+    UNUR_DISTR* unur_distr_matr_new(int n_rows, int n_cols)
+
+    int unur_distr_matr_get_dim(UNUR_DISTR* distribution, int* n_rows, int* n_cols)
+
+    UNUR_PAR* unur_auto_new(UNUR_DISTR* distribution)
+
+    int unur_auto_set_logss(UNUR_PAR* parameters, int logss)
+
+    UNUR_PAR* unur_dari_new(UNUR_DISTR* distribution)
+
+    int unur_dari_set_squeeze(UNUR_PAR* parameters, int squeeze)
+
+    int unur_dari_set_tablesize(UNUR_PAR* parameters, int size)
+
+    int unur_dari_set_cpfactor(UNUR_PAR* parameters, double cp_factor)
+
+    int unur_dari_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_dari_chg_verify(UNUR_GEN* generator, int verify)
+
+    UNUR_PAR* unur_dau_new(UNUR_DISTR* distribution)
+
+    int unur_dau_set_urnfactor(UNUR_PAR* parameters, double factor)
+
+    UNUR_PAR* unur_dgt_new(UNUR_DISTR* distribution)
+
+    int unur_dgt_set_guidefactor(UNUR_PAR* parameters, double factor)
+
+    int unur_dgt_set_variant(UNUR_PAR* parameters, unsigned variant)
+
+    int unur_dgt_eval_invcdf_recycle(UNUR_GEN* generator, double u, double* recycle)
+
+    int unur_dgt_eval_invcdf(UNUR_GEN* generator, double u)
+
+    UNUR_PAR* unur_dsrou_new(UNUR_DISTR* distribution)
+
+    int unur_dsrou_set_cdfatmode(UNUR_PAR* parameters, double Fmode)
+
+    int unur_dsrou_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_dsrou_chg_verify(UNUR_GEN* generator, int verify)
+
+    int unur_dsrou_chg_cdfatmode(UNUR_GEN* generator, double Fmode)
+
+    UNUR_PAR* unur_dss_new(UNUR_DISTR* distribution)
+
+    UNUR_PAR* unur_arou_new(UNUR_DISTR* distribution)
+
+    int unur_arou_set_usedars(UNUR_PAR* parameters, int usedars)
+
+    int unur_arou_set_darsfactor(UNUR_PAR* parameters, double factor)
+
+    int unur_arou_set_max_sqhratio(UNUR_PAR* parameters, double max_ratio)
+
+    double unur_arou_get_sqhratio(UNUR_GEN* generator)
+
+    double unur_arou_get_hatarea(UNUR_GEN* generator)
+
+    double unur_arou_get_squeezearea(UNUR_GEN* generator)
+
+    int unur_arou_set_max_segments(UNUR_PAR* parameters, int max_segs)
+
+    int unur_arou_set_cpoints(UNUR_PAR* parameters, int n_stp, double* stp)
+
+    int unur_arou_set_usecenter(UNUR_PAR* parameters, int usecenter)
+
+    int unur_arou_set_guidefactor(UNUR_PAR* parameters, double factor)
+
+    int unur_arou_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_arou_chg_verify(UNUR_GEN* generator, int verify)
+
+    int unur_arou_set_pedantic(UNUR_PAR* parameters, int pedantic)
+
+    UNUR_PAR* unur_ars_new(UNUR_DISTR* distribution)
+
+    int unur_ars_set_max_intervals(UNUR_PAR* parameters, int max_ivs)
+
+    int unur_ars_set_cpoints(UNUR_PAR* parameters, int n_cpoints, double* cpoints)
+
+    int unur_ars_set_reinit_percentiles(UNUR_PAR* parameters, int n_percentiles, double* percentiles)
+
+    int unur_ars_chg_reinit_percentiles(UNUR_GEN* generator, int n_percentiles, double* percentiles)
+
+    int unur_ars_set_reinit_ncpoints(UNUR_PAR* parameters, int ncpoints)
+
+    int unur_ars_chg_reinit_ncpoints(UNUR_GEN* generator, int ncpoints)
+
+    int unur_ars_set_max_iter(UNUR_PAR* parameters, int max_iter)
+
+    int unur_ars_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_ars_chg_verify(UNUR_GEN* generator, int verify)
+
+    int unur_ars_set_pedantic(UNUR_PAR* parameters, int pedantic)
+
+    double unur_ars_get_loghatarea(UNUR_GEN* generator)
+
+    double unur_ars_eval_invcdfhat(UNUR_GEN* generator, double u)
+
+    UNUR_PAR* unur_hinv_new(UNUR_DISTR* distribution)
+
+    int unur_hinv_set_order(UNUR_PAR* parameters, int order)
+
+    int unur_hinv_set_u_resolution(UNUR_PAR* parameters, double u_resolution)
+
+    int unur_hinv_set_cpoints(UNUR_PAR* parameters, double* stp, int n_stp)
+
+    int unur_hinv_set_boundary(UNUR_PAR* parameters, double left, double right)
+
+    int unur_hinv_set_guidefactor(UNUR_PAR* parameters, double factor)
+
+    int unur_hinv_set_max_intervals(UNUR_PAR* parameters, int max_ivs)
+
+    int unur_hinv_get_n_intervals(UNUR_GEN* generator)
+
+    double unur_hinv_eval_approxinvcdf(UNUR_GEN* generator, double u)
+
+    int unur_hinv_chg_truncated(UNUR_GEN* generator, double left, double right)
+
+    int unur_hinv_estimate_error(UNUR_GEN* generator, int samplesize, double* max_error, double* MAE)
+
+    UNUR_PAR* unur_hrb_new(UNUR_DISTR* distribution)
+
+    int unur_hrb_set_upperbound(UNUR_PAR* parameters, double upperbound)
+
+    int unur_hrb_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_hrb_chg_verify(UNUR_GEN* generator, int verify)
+
+    UNUR_PAR* unur_hrd_new(UNUR_DISTR* distribution)
+
+    int unur_hrd_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_hrd_chg_verify(UNUR_GEN* generator, int verify)
+
+    UNUR_PAR* unur_hri_new(UNUR_DISTR* distribution)
+
+    int unur_hri_set_p0(UNUR_PAR* parameters, double p0)
+
+    int unur_hri_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_hri_chg_verify(UNUR_GEN* generator, int verify)
+
+    UNUR_PAR* unur_itdr_new(UNUR_DISTR* distribution)
+
+    int unur_itdr_set_xi(UNUR_PAR* parameters, double xi)
+
+    int unur_itdr_set_cp(UNUR_PAR* parameters, double cp)
+
+    int unur_itdr_set_ct(UNUR_PAR* parameters, double ct)
+
+    double unur_itdr_get_xi(UNUR_GEN* generator)
+
+    double unur_itdr_get_cp(UNUR_GEN* generator)
+
+    double unur_itdr_get_ct(UNUR_GEN* generator)
+
+    double unur_itdr_get_area(UNUR_GEN* generator)
+
+    int unur_itdr_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_itdr_chg_verify(UNUR_GEN* generator, int verify)
+
+    UNUR_PAR* unur_mcorr_new(UNUR_DISTR* distribution)
+
+    int unur_mcorr_set_eigenvalues(UNUR_PAR* par, double* eigenvalues)
+
+    int unur_mcorr_chg_eigenvalues(UNUR_GEN* gen, double* eigenvalues)
+
+    UNUR_PAR* unur_ninv_new(UNUR_DISTR* distribution)
+
+    int unur_ninv_set_useregula(UNUR_PAR* parameters)
+
+    int unur_ninv_set_usenewton(UNUR_PAR* parameters)
+
+    int unur_ninv_set_usebisect(UNUR_PAR* parameters)
+
+    int unur_ninv_set_max_iter(UNUR_PAR* parameters, int max_iter)
+
+    int unur_ninv_chg_max_iter(UNUR_GEN* generator, int max_iter)
+
+    int unur_ninv_set_x_resolution(UNUR_PAR* parameters, double x_resolution)
+
+    int unur_ninv_chg_x_resolution(UNUR_GEN* generator, double x_resolution)
+
+    int unur_ninv_set_u_resolution(UNUR_PAR* parameters, double u_resolution)
+
+    int unur_ninv_chg_u_resolution(UNUR_GEN* generator, double u_resolution)
+
+    int unur_ninv_set_start(UNUR_PAR* parameters, double left, double right)
+
+    int unur_ninv_chg_start(UNUR_GEN* gen, double left, double right)
+
+    int unur_ninv_set_table(UNUR_PAR* parameters, int no_of_points)
+
+    int unur_ninv_chg_table(UNUR_GEN* gen, int no_of_points)
+
+    int unur_ninv_chg_truncated(UNUR_GEN* gen, double left, double right)
+
+    double unur_ninv_eval_approxinvcdf(UNUR_GEN* generator, double u)
+
+    UNUR_PAR* unur_nrou_new(UNUR_DISTR* distribution)
+
+    int unur_nrou_set_u(UNUR_PAR* parameters, double umin, double umax)
+
+    int unur_nrou_set_v(UNUR_PAR* parameters, double vmax)
+
+    int unur_nrou_set_r(UNUR_PAR* parameters, double r)
+
+    int unur_nrou_set_center(UNUR_PAR* parameters, double center)
+
+    int unur_nrou_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_nrou_chg_verify(UNUR_GEN* generator, int verify)
+
+    UNUR_PAR* unur_pinv_new(UNUR_DISTR* distribution)
+
+    int unur_pinv_set_order(UNUR_PAR* parameters, int order)
+
+    int unur_pinv_set_smoothness(UNUR_PAR* parameters, int smoothness)
+
+    int unur_pinv_set_u_resolution(UNUR_PAR* parameters, double u_resolution)
+
+    int unur_pinv_set_use_upoints(UNUR_PAR* parameters, int use_upoints)
+
+    int unur_pinv_set_usepdf(UNUR_PAR* parameters)
+
+    int unur_pinv_set_usecdf(UNUR_PAR* parameters)
+
+    int unur_pinv_set_boundary(UNUR_PAR* parameters, double left, double right)
+
+    int unur_pinv_set_searchboundary(UNUR_PAR* parameters, int left, int right)
+
+    int unur_pinv_set_max_intervals(UNUR_PAR* parameters, int max_ivs)
+
+    int unur_pinv_get_n_intervals(UNUR_GEN* generator)
+
+    int unur_pinv_set_keepcdf(UNUR_PAR* parameters, int keepcdf)
+
+    double unur_pinv_eval_approxinvcdf(UNUR_GEN* generator, double u)
+
+    double unur_pinv_eval_approxcdf(UNUR_GEN* generator, double x)
+
+    int unur_pinv_estimate_error(UNUR_GEN* generator, int samplesize, double* max_error, double* MAE)
+
+    UNUR_PAR* unur_srou_new(UNUR_DISTR* distribution)
+
+    int unur_srou_set_r(UNUR_PAR* parameters, double r)
+
+    int unur_srou_set_cdfatmode(UNUR_PAR* parameters, double Fmode)
+
+    int unur_srou_set_pdfatmode(UNUR_PAR* parameters, double fmode)
+
+    int unur_srou_set_usesqueeze(UNUR_PAR* parameters, int usesqueeze)
+
+    int unur_srou_set_usemirror(UNUR_PAR* parameters, int usemirror)
+
+    int unur_srou_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_srou_chg_verify(UNUR_GEN* generator, int verify)
+
+    int unur_srou_chg_cdfatmode(UNUR_GEN* generator, double Fmode)
+
+    int unur_srou_chg_pdfatmode(UNUR_GEN* generator, double fmode)
+
+    UNUR_PAR* unur_ssr_new(UNUR_DISTR* distribution)
+
+    int unur_ssr_set_cdfatmode(UNUR_PAR* parameters, double Fmode)
+
+    int unur_ssr_set_pdfatmode(UNUR_PAR* parameters, double fmode)
+
+    int unur_ssr_set_usesqueeze(UNUR_PAR* parameters, int usesqueeze)
+
+    int unur_ssr_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_ssr_chg_verify(UNUR_GEN* generator, int verify)
+
+    int unur_ssr_chg_cdfatmode(UNUR_GEN* generator, double Fmode)
+
+    int unur_ssr_chg_pdfatmode(UNUR_GEN* generator, double fmode)
+
+    UNUR_PAR* unur_tabl_new(UNUR_DISTR* distribution)
+
+    int unur_tabl_set_variant_ia(UNUR_PAR* parameters, int use_ia)
+
+    int unur_tabl_set_cpoints(UNUR_PAR* parameters, int n_cpoints, double* cpoints)
+
+    int unur_tabl_set_nstp(UNUR_PAR* parameters, int n_stp)
+
+    int unur_tabl_set_useear(UNUR_PAR* parameters, int useear)
+
+    int unur_tabl_set_areafraction(UNUR_PAR* parameters, double fraction)
+
+    int unur_tabl_set_usedars(UNUR_PAR* parameters, int usedars)
+
+    int unur_tabl_set_darsfactor(UNUR_PAR* parameters, double factor)
+
+    int unur_tabl_set_variant_splitmode(UNUR_PAR* parameters, unsigned splitmode)
+
+    int unur_tabl_set_max_sqhratio(UNUR_PAR* parameters, double max_ratio)
+
+    double unur_tabl_get_sqhratio(UNUR_GEN* generator)
+
+    double unur_tabl_get_hatarea(UNUR_GEN* generator)
+
+    double unur_tabl_get_squeezearea(UNUR_GEN* generator)
+
+    int unur_tabl_set_max_intervals(UNUR_PAR* parameters, int max_ivs)
+
+    int unur_tabl_get_n_intervals(UNUR_GEN* generator)
+
+    int unur_tabl_set_slopes(UNUR_PAR* parameters, double* slopes, int n_slopes)
+
+    int unur_tabl_set_guidefactor(UNUR_PAR* parameters, double factor)
+
+    int unur_tabl_set_boundary(UNUR_PAR* parameters, double left, double right)
+
+    int unur_tabl_chg_truncated(UNUR_GEN* gen, double left, double right)
+
+    int unur_tabl_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_tabl_chg_verify(UNUR_GEN* generator, int verify)
+
+    int unur_tabl_set_pedantic(UNUR_PAR* parameters, int pedantic)
+
+    UNUR_PAR* unur_tdr_new(UNUR_DISTR* distribution)
+
+    int unur_tdr_set_c(UNUR_PAR* parameters, double c)
+
+    int unur_tdr_set_variant_gw(UNUR_PAR* parameters)
+
+    int unur_tdr_set_variant_ps(UNUR_PAR* parameters)
+
+    int unur_tdr_set_variant_ia(UNUR_PAR* parameters)
+
+    int unur_tdr_set_usedars(UNUR_PAR* parameters, int usedars)
+
+    int unur_tdr_set_darsfactor(UNUR_PAR* parameters, double factor)
+
+    int unur_tdr_set_cpoints(UNUR_PAR* parameters, int n_stp, double* stp)
+
+    int unur_tdr_set_reinit_percentiles(UNUR_PAR* parameters, int n_percentiles, double* percentiles)
+
+    int unur_tdr_chg_reinit_percentiles(UNUR_GEN* generator, int n_percentiles, double* percentiles)
+
+    int unur_tdr_set_reinit_ncpoints(UNUR_PAR* parameters, int ncpoints)
+
+    int unur_tdr_chg_reinit_ncpoints(UNUR_GEN* generator, int ncpoints)
+
+    int unur_tdr_chg_truncated(UNUR_GEN* gen, double left, double right)
+
+    int unur_tdr_set_max_sqhratio(UNUR_PAR* parameters, double max_ratio)
+
+    double unur_tdr_get_sqhratio(UNUR_GEN* generator)
+
+    double unur_tdr_get_hatarea(UNUR_GEN* generator)
+
+    double unur_tdr_get_squeezearea(UNUR_GEN* generator)
+
+    int unur_tdr_set_max_intervals(UNUR_PAR* parameters, int max_ivs)
+
+    int unur_tdr_set_usecenter(UNUR_PAR* parameters, int usecenter)
+
+    int unur_tdr_set_usemode(UNUR_PAR* parameters, int usemode)
+
+    int unur_tdr_set_guidefactor(UNUR_PAR* parameters, double factor)
+
+    int unur_tdr_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_tdr_chg_verify(UNUR_GEN* generator, int verify)
+
+    int unur_tdr_set_pedantic(UNUR_PAR* parameters, int pedantic)
+
+    double unur_tdr_eval_invcdfhat(UNUR_GEN* generator, double u, double* hx, double* fx, double* sqx)
+
+    int _unur_tdr_is_ARS_running(UNUR_GEN* generator)
+
+    UNUR_PAR* unur_utdr_new(UNUR_DISTR* distribution)
+
+    int unur_utdr_set_pdfatmode(UNUR_PAR* parameters, double fmode)
+
+    int unur_utdr_set_cpfactor(UNUR_PAR* parameters, double cp_factor)
+
+    int unur_utdr_set_deltafactor(UNUR_PAR* parameters, double delta)
+
+    int unur_utdr_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_utdr_chg_verify(UNUR_GEN* generator, int verify)
+
+    int unur_utdr_chg_pdfatmode(UNUR_GEN* generator, double fmode)
+
+    UNUR_PAR* unur_empk_new(UNUR_DISTR* distribution)
+
+    int unur_empk_set_kernel(UNUR_PAR* parameters, unsigned kernel)
+
+    int unur_empk_set_kernelgen(UNUR_PAR* parameters, UNUR_GEN* kernelgen, double alpha, double kernelvar)
+
+    int unur_empk_set_beta(UNUR_PAR* parameters, double beta)
+
+    int unur_empk_set_smoothing(UNUR_PAR* parameters, double smoothing)
+
+    int unur_empk_chg_smoothing(UNUR_GEN* generator, double smoothing)
+
+    int unur_empk_set_varcor(UNUR_PAR* parameters, int varcor)
+
+    int unur_empk_chg_varcor(UNUR_GEN* generator, int varcor)
+
+    int unur_empk_set_positive(UNUR_PAR* parameters, int positive)
+
+    UNUR_PAR* unur_empl_new(UNUR_DISTR* distribution)
+
+    UNUR_PAR* unur_hist_new(UNUR_DISTR* distribution)
+
+    UNUR_PAR* unur_mvtdr_new(UNUR_DISTR* distribution)
+
+    int unur_mvtdr_set_stepsmin(UNUR_PAR* parameters, int stepsmin)
+
+    int unur_mvtdr_set_boundsplitting(UNUR_PAR* parameters, double boundsplitting)
+
+    int unur_mvtdr_set_maxcones(UNUR_PAR* parameters, int maxcones)
+
+    int unur_mvtdr_get_ncones(UNUR_GEN* generator)
+
+    double unur_mvtdr_get_hatvol(UNUR_GEN* generator)
+
+    int unur_mvtdr_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_mvtdr_chg_verify(UNUR_GEN* generator, int verify)
+
+    UNUR_PAR* unur_norta_new(UNUR_DISTR* distribution)
+
+    UNUR_PAR* unur_vempk_new(UNUR_DISTR* distribution)
+
+    int unur_vempk_set_smoothing(UNUR_PAR* parameters, double smoothing)
+
+    int unur_vempk_chg_smoothing(UNUR_GEN* generator, double smoothing)
+
+    int unur_vempk_set_varcor(UNUR_PAR* parameters, int varcor)
+
+    int unur_vempk_chg_varcor(UNUR_GEN* generator, int varcor)
+
+    UNUR_PAR* unur_vnrou_new(UNUR_DISTR* distribution)
+
+    int unur_vnrou_set_u(UNUR_PAR* parameters, double* umin, double* umax)
+
+    int unur_vnrou_chg_u(UNUR_GEN* generator, double* umin, double* umax)
+
+    int unur_vnrou_set_v(UNUR_PAR* parameters, double vmax)
+
+    int unur_vnrou_chg_v(UNUR_GEN* generator, double vmax)
+
+    int unur_vnrou_set_r(UNUR_PAR* parameters, double r)
+
+    int unur_vnrou_set_verify(UNUR_PAR* parameters, int verify)
+
+    int unur_vnrou_chg_verify(UNUR_GEN* generator, int verify)
+
+    double unur_vnrou_get_volumehat(UNUR_GEN* generator)
+
+    UNUR_PAR* unur_gibbs_new(UNUR_DISTR* distribution)
+
+    int unur_gibbs_set_variant_coordinate(UNUR_PAR* parameters)
+
+    int unur_gibbs_set_variant_random_direction(UNUR_PAR* parameters)
+
+    int unur_gibbs_set_c(UNUR_PAR* parameters, double c)
+
+    int unur_gibbs_set_startingpoint(UNUR_PAR* parameters, double* x0)
+
+    int unur_gibbs_set_thinning(UNUR_PAR* parameters, int thinning)
+
+    int unur_gibbs_set_burnin(UNUR_PAR* parameters, int burnin)
+
+    double* unur_gibbs_get_state(UNUR_GEN* generator)
+
+    int unur_gibbs_chg_state(UNUR_GEN* generator, double* state)
+
+    int unur_gibbs_reset_state(UNUR_GEN* generator)
+
+    UNUR_PAR* unur_hitro_new(UNUR_DISTR* distribution)
+
+    int unur_hitro_set_variant_coordinate(UNUR_PAR* parameters)
+
+    int unur_hitro_set_variant_random_direction(UNUR_PAR* parameters)
+
+    int unur_hitro_set_use_adaptiveline(UNUR_PAR* parameters, int adaptive)
+
+    int unur_hitro_set_use_boundingrectangle(UNUR_PAR* parameters, int rectangle)
+
+    int unur_hitro_set_use_adaptiverectangle(UNUR_PAR* parameters, int adaptive)
+
+    int unur_hitro_set_r(UNUR_PAR* parameters, double r)
+
+    int unur_hitro_set_v(UNUR_PAR* parameters, double vmax)
+
+    int unur_hitro_set_u(UNUR_PAR* parameters, double* umin, double* umax)
+
+    int unur_hitro_set_adaptive_multiplier(UNUR_PAR* parameters, double factor)
+
+    int unur_hitro_set_startingpoint(UNUR_PAR* parameters, double* x0)
+
+    int unur_hitro_set_thinning(UNUR_PAR* parameters, int thinning)
+
+    int unur_hitro_set_burnin(UNUR_PAR* parameters, int burnin)
+
+    double* unur_hitro_get_state(UNUR_GEN* generator)
+
+    int unur_hitro_chg_state(UNUR_GEN* generator, double* state)
+
+    int unur_hitro_reset_state(UNUR_GEN* generator)
+
+    UNUR_PAR* unur_cstd_new(UNUR_DISTR* distribution)
+
+    int unur_cstd_set_variant(UNUR_PAR* parameters, unsigned variant)
+
+    int unur_cstd_chg_truncated(UNUR_GEN* generator, double left, double right)
+
+    double unur_cstd_eval_invcdf(UNUR_GEN* generator, double u)
+
+    UNUR_PAR* unur_dstd_new(UNUR_DISTR* distribution)
+
+    int unur_dstd_set_variant(UNUR_PAR* parameters, unsigned variant)
+
+    int unur_dstd_chg_truncated(UNUR_GEN* generator, int left, int right)
+
+    int unur_dstd_eval_invcdf(UNUR_GEN* generator, double u)
+
+    UNUR_PAR* unur_mvstd_new(UNUR_DISTR* distribution)
+
+    UNUR_PAR* unur_mixt_new(int n, double* prob, UNUR_GEN** comp)
+
+    int unur_mixt_set_useinversion(UNUR_PAR* parameters, int useinv)
+
+    double unur_mixt_eval_invcdf(UNUR_GEN* generator, double u)
+
+    UNUR_PAR* unur_cext_new(UNUR_DISTR* distribution)
+
+    ctypedef int (*_unur_cext_set_init_init_ft)(UNUR_GEN* gen)
+
+    int unur_cext_set_init(UNUR_PAR* parameters, _unur_cext_set_init_init_ft init)
+
+    ctypedef double (*_unur_cext_set_sample_sample_ft)(UNUR_GEN* gen)
+
+    int unur_cext_set_sample(UNUR_PAR* parameters, _unur_cext_set_sample_sample_ft sample)
+
+    void* unur_cext_get_params(UNUR_GEN* generator, size_t size)
+
+    double* unur_cext_get_distrparams(UNUR_GEN* generator)
+
+    int unur_cext_get_ndistrparams(UNUR_GEN* generator)
+
+    UNUR_PAR* unur_dext_new(UNUR_DISTR* distribution)
+
+    ctypedef int (*_unur_dext_set_init_init_ft)(UNUR_GEN* gen)
+
+    int unur_dext_set_init(UNUR_PAR* parameters, _unur_dext_set_init_init_ft init)
+
+    ctypedef int (*_unur_dext_set_sample_sample_ft)(UNUR_GEN* gen)
+
+    int unur_dext_set_sample(UNUR_PAR* parameters, _unur_dext_set_sample_sample_ft sample)
+
+    void* unur_dext_get_params(UNUR_GEN* generator, size_t size)
+
+    double* unur_dext_get_distrparams(UNUR_GEN* generator)
+
+    int unur_dext_get_ndistrparams(UNUR_GEN* generator)
+
+    UNUR_PAR* unur_unif_new(UNUR_DISTR* dummy)
+
+    UNUR_GEN* unur_str2gen(char* string)
+
+    UNUR_DISTR* unur_str2distr(char* string)
+
+    UNUR_GEN* unur_makegen_ssu(char* distrstr, char* methodstr, UNUR_URNG* urng)
+
+    UNUR_GEN* unur_makegen_dsu(UNUR_DISTR* distribution, char* methodstr, UNUR_URNG* urng)
+
+    UNUR_PAR* _unur_str2par(UNUR_DISTR* distribution, char* method, unur_slist** mlist)
+
+    UNUR_GEN* unur_init(UNUR_PAR* parameters)
+
+    int unur_reinit(UNUR_GEN* generator)
+
+    int unur_sample_discr(UNUR_GEN* generator)
+
+    double unur_sample_cont(UNUR_GEN* generator)
+
+    int unur_sample_vec(UNUR_GEN* generator, double* vector)
+
+    int unur_sample_matr(UNUR_GEN* generator, double* matrix)
+
+    double unur_quantile(UNUR_GEN* generator, double U)
+
+    void unur_free(UNUR_GEN* generator)
+
+    char* unur_gen_info(UNUR_GEN* generator, int help)
+
+    int unur_get_dimension(UNUR_GEN* generator)
+
+    char* unur_get_genid(UNUR_GEN* generator)
+
+    UNUR_DISTR* unur_get_distr(UNUR_GEN* generator)
+
+    int unur_set_use_distr_privatecopy(UNUR_PAR* parameters, int use_privatecopy)
+
+    UNUR_GEN* unur_gen_clone(UNUR_GEN* gen)
+
+    void unur_par_free(UNUR_PAR* par)
+
+    cdef enum:
+        UNUR_DISTR_GENERIC
+        UNUR_DISTR_CORDER
+        UNUR_DISTR_CXTRANS
+        UNUR_DISTR_CONDI
+        UNUR_DISTR_BETA
+        UNUR_DISTR_CAUCHY
+        UNUR_DISTR_CHI
+        UNUR_DISTR_CHISQUARE
+        UNUR_DISTR_EPANECHNIKOV
+        UNUR_DISTR_EXPONENTIAL
+        UNUR_DISTR_EXTREME_I
+        UNUR_DISTR_EXTREME_II
+        UNUR_DISTR_F
+        UNUR_DISTR_GAMMA
+        UNUR_DISTR_GHYP
+        UNUR_DISTR_GIG
+        UNUR_DISTR_GIG2
+        UNUR_DISTR_HYPERBOLIC
+        UNUR_DISTR_IG
+        UNUR_DISTR_LAPLACE
+        UNUR_DISTR_LOGISTIC
+        UNUR_DISTR_LOGNORMAL
+        UNUR_DISTR_LOMAX
+        UNUR_DISTR_NORMAL
+        UNUR_DISTR_GAUSSIAN
+        UNUR_DISTR_PARETO
+        UNUR_DISTR_POWEREXPONENTIAL
+        UNUR_DISTR_RAYLEIGH
+        UNUR_DISTR_SLASH
+        UNUR_DISTR_STUDENT
+        UNUR_DISTR_TRIANGULAR
+        UNUR_DISTR_UNIFORM
+        UNUR_DISTR_BOXCAR
+        UNUR_DISTR_WEIBULL
+        UNUR_DISTR_BURR_I
+        UNUR_DISTR_BURR_II
+        UNUR_DISTR_BURR_III
+        UNUR_DISTR_BURR_IV
+        UNUR_DISTR_BURR_V
+        UNUR_DISTR_BURR_VI
+        UNUR_DISTR_BURR_VII
+        UNUR_DISTR_BURR_VIII
+        UNUR_DISTR_BURR_IX
+        UNUR_DISTR_BURR_X
+        UNUR_DISTR_BURR_XI
+        UNUR_DISTR_BURR_XII
+        UNUR_DISTR_BINOMIAL
+        UNUR_DISTR_GEOMETRIC
+        UNUR_DISTR_HYPERGEOMETRIC
+        UNUR_DISTR_LOGARITHMIC
+        UNUR_DISTR_NEGATIVEBINOMIAL
+        UNUR_DISTR_POISSON
+        UNUR_DISTR_ZIPF
+        UNUR_DISTR_MCAUCHY
+        UNUR_DISTR_MNORMAL
+        UNUR_DISTR_MSTUDENT
+        UNUR_DISTR_MEXPONENTIAL
+        UNUR_DISTR_COPULA
+        UNUR_DISTR_MCORRELATION
+
+    UNUR_DISTR* unur_distr_beta(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_burr(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_cauchy(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_chi(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_chisquare(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_exponential(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_extremeI(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_extremeII(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_F(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_gamma(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_ghyp(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_gig(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_gig2(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_hyperbolic(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_ig(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_laplace(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_logistic(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_lognormal(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_lomax(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_normal(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_pareto(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_powerexponential(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_rayleigh(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_slash(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_student(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_triangular(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_uniform(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_weibull(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_multinormal(int dim, double* mean, double* covar)
+
+    UNUR_DISTR* unur_distr_multicauchy(int dim, double* mean, double* covar)
+
+    UNUR_DISTR* unur_distr_multistudent(int dim, double nu, double* mean, double* covar)
+
+    UNUR_DISTR* unur_distr_multiexponential(int dim, double* sigma, double* theta)
+
+    UNUR_DISTR* unur_distr_copula(int dim, double* rankcorr)
+
+    UNUR_DISTR* unur_distr_correlation(int n)
+
+    UNUR_DISTR* unur_distr_binomial(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_geometric(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_hypergeometric(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_logarithmic(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_negativebinomial(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_poisson(double* params, int n_params)
+
+    UNUR_DISTR* unur_distr_zipf(double* params, int n_params)
+
+    FILE* unur_set_stream(FILE* new_stream)
+
+    FILE* unur_get_stream()
+
+    int unur_set_debug(UNUR_PAR* parameters, unsigned debug)
+
+    int unur_chg_debug(UNUR_GEN* generator, unsigned debug)
+
+    int unur_set_default_debug(unsigned debug)
+
+    int unur_errno
+
+    int unur_get_errno()
+
+    void unur_reset_errno()
+
+    char* unur_get_strerror(int errnocode)
+
+    UNUR_ERROR_HANDLER* unur_set_error_handler(UNUR_ERROR_HANDLER* new_handler)
+
+    UNUR_ERROR_HANDLER* unur_set_error_handler_off()
+
+    cdef enum:
+        UNUR_SUCCESS
+        UNUR_FAILURE
+        UNUR_ERR_DISTR_SET
+        UNUR_ERR_DISTR_GET
+        UNUR_ERR_DISTR_NPARAMS
+        UNUR_ERR_DISTR_DOMAIN
+        UNUR_ERR_DISTR_GEN
+        UNUR_ERR_DISTR_REQUIRED
+        UNUR_ERR_DISTR_UNKNOWN
+        UNUR_ERR_DISTR_INVALID
+        UNUR_ERR_DISTR_DATA
+        UNUR_ERR_DISTR_PROP
+        UNUR_ERR_PAR_SET
+        UNUR_ERR_PAR_VARIANT
+        UNUR_ERR_PAR_INVALID
+        UNUR_ERR_GEN
+        UNUR_ERR_GEN_DATA
+        UNUR_ERR_GEN_CONDITION
+        UNUR_ERR_GEN_INVALID
+        UNUR_ERR_GEN_SAMPLING
+        UNUR_ERR_NO_REINIT
+        UNUR_ERR_NO_QUANTILE
+        UNUR_ERR_URNG
+        UNUR_ERR_URNG_MISS
+        UNUR_ERR_STR
+        UNUR_ERR_STR_UNKNOWN
+        UNUR_ERR_STR_SYNTAX
+        UNUR_ERR_STR_INVALID
+        UNUR_ERR_FSTR_SYNTAX
+        UNUR_ERR_FSTR_DERIV
+        UNUR_ERR_DOMAIN
+        UNUR_ERR_ROUNDOFF
+        UNUR_ERR_MALLOC
+        UNUR_ERR_NULL
+        UNUR_ERR_COOKIE
+        UNUR_ERR_GENERIC
+        UNUR_ERR_SILENT
+        UNUR_ERR_INF
+        UNUR_ERR_NAN
+        UNUR_ERR_COMPILE
+        UNUR_ERR_SHOULD_NOT_HAPPEN
+
+    double INFINITY
+
+    unur_slist* _unur_slist_new()
+
+    int _unur_slist_append(unur_slist* slist, void* element)
+
+    int _unur_slist_length(unur_slist* slist)
+
+    void* _unur_slist_get(unur_slist* slist, int n)
+
+    void* _unur_slist_replace(unur_slist* slist, int n, void* element)
+
+    void _unur_slist_free(unur_slist* slist)

--- a/scipy/stats/_unuran/unuran_callback.h
+++ b/scipy/stats/_unuran/unuran_callback.h
@@ -1,0 +1,141 @@
+#include <Python.h>
+#include "ccallback.h"
+#include "unuran.h"
+
+#define UNURAN_THUNK(CAST_FUNC, FUNCNAME, LEN)                                              \
+    /* If an error has occured, return INFINITY. */                                         \
+    if (PyErr_Occurred()) return UNUR_INFINITY;                                             \
+    ccallback_t *callback = ccallback_obtain();                                             \
+    PyObject *extra_args = (PyObject *)callback->info_p;                                    \
+                                                                                            \
+    PyObject *arg1 = NULL, *argobj = NULL, *arglist = NULL, *res = NULL, *funcname = NULL;  \
+    double result = 0.;                                                                     \
+    int error = 0;                                                                          \
+                                                                                            \
+    argobj = CAST_FUNC(x);                                                                  \
+    if (argobj == NULL) {                                                                   \
+        error = 1;                                                                          \
+        goto done;                                                                          \
+    }                                                                                       \
+                                                                                            \
+    funcname = Py_BuildValue("s#", FUNCNAME, LEN);                                          \
+    if (funcname == NULL) {                                                                 \
+        error = 1;                                                                          \
+        goto done;                                                                          \
+    }                                                                                       \
+                                                                                            \
+    arg1 = PyTuple_New(2);                                                                  \
+    if (arg1 == NULL) {                                                                     \
+        error = 1;                                                                          \
+        goto done;                                                                          \
+    }                                                                                       \
+                                                                                            \
+    PyTuple_SET_ITEM(arg1, 0, argobj);                                                      \
+    PyTuple_SET_ITEM(arg1, 1, funcname);                                                    \
+    argobj = NULL; funcname = NULL;                                                         \
+                                                                                            \
+    arglist = PySequence_Concat(arg1, extra_args);                                          \
+    if (arglist == NULL) {                                                                  \
+        error = 1;                                                                          \
+        goto done;                                                                          \
+    }                                                                                       \
+                                                                                            \
+    res = PyObject_CallObject(callback->py_function, arglist);                              \
+    if (res == NULL) {                                                                      \
+        error = 1;                                                                          \
+        goto done;                                                                          \
+    }                                                                                       \
+                                                                                            \
+    result = PyFloat_AsDouble(res);                                                         \
+    if (PyErr_Occurred()) {                                                                 \
+        error = 1;                                                                          \
+        goto done;                                                                          \
+    }                                                                                       \
+                                                                                            \
+done:                                                                                       \
+    Py_XDECREF(arg1);                                                                       \
+    Py_XDECREF(argobj);                                                                     \
+    Py_XDECREF(funcname);                                                                   \
+    Py_XDECREF(arglist);                                                                    \
+    Py_XDECREF(res);                                                                        \
+                                                                                            \
+    if (error) {                                                                            \
+        /* nonlocal return causes memory leaks. So, if the Python error variable has been   \
+           set, just return INFINITY. This will cause an error in UNU.RAN and it            \
+           will return an errorcode or NULL value. We can then raise the error from Cython  \
+           by checking if the Python error variable variable has been set when an           \
+           errorcode/NULL value is returned. */                                             \
+        return UNUR_INFINITY;                                                               \
+    }                                                                                       \
+                                                                                            \
+    return result
+
+void error_handler(const char *objid, const char *file, int line, const char *errortype, int unur_errno, const char *reason)
+{
+    if ( unur_errno != UNUR_SUCCESS ) {
+        FILE *LOG = unur_get_stream();
+        const char *objid_    = (objid  == NULL || strcmp(objid , "") == 0) ? "unknown"        : objid;
+        const char *reason_   = (reason == NULL || strcmp(reason, "") == 0) ? "unknown error!" : reason;
+        const char *errno_msg = unur_get_strerror(unur_errno);
+        if ( strcmp(errortype, "error") == 0 ) {
+            fprintf(LOG, "[objid: %s] %d : %s => %s", objid_, unur_errno, reason_, errno_msg);
+        }
+        else {
+            PyErr_WarnFormat(PyExc_RuntimeWarning, 1, "[objid: %s] %d : %s => %s", objid_, unur_errno, reason_, errno_msg);
+        }
+    }
+}
+
+static ccallback_signature_t unuran_call_signatures[] = {
+    {NULL}
+};
+
+int init_unuran_callback(ccallback_t *callback, PyObject *fcn, PyObject *extra_args)
+{
+    int ret;
+    int flags = CCALLBACK_OBTAIN;
+
+    ret = ccallback_prepare(callback, unuran_call_signatures, fcn, flags);
+    if (ret == -1) {
+        return -1;
+    }
+
+    callback->info_p = (void *)extra_args;
+
+    return 0;
+}
+
+int release_unuran_callback(ccallback_t *callback) {
+    int ret = ccallback_release(callback);
+    return ret;
+}
+
+
+/* ********************************************************************************** */
+/* ********************************* UNU.RAN Thunks ********************************* */
+/* ********************************************************************************** */
+
+double pmf_thunk(int x, const struct unur_distr *distr)
+{
+    UNURAN_THUNK(PyLong_FromLong, "pmf", 3);
+}
+
+double pdf_thunk(double x, const struct unur_distr *distr)
+{
+    UNURAN_THUNK(PyFloat_FromDouble, "pdf", 3);
+}
+
+double dpdf_thunk(double x, const struct unur_distr *distr)
+{
+    UNURAN_THUNK(PyFloat_FromDouble, "dpdf", 4);
+}
+
+double cont_cdf_thunk(double x, const struct unur_distr *distr)
+{
+    UNURAN_THUNK(PyFloat_FromDouble, "cdf", 3);
+}
+
+double discr_cdf_thunk(int x, const struct unur_distr *distr)
+{
+    UNURAN_THUNK(PyLong_FromLong, "cdf", 3);
+}

--- a/scipy/stats/_unuran/unuran_wrapper.pyi
+++ b/scipy/stats/_unuran/unuran_wrapper.pyi
@@ -1,0 +1,71 @@
+import numpy as np
+from typing import Union, Any, Tuple, List, overload, Callable
+from typing_extensions import Protocol
+import numpy.typing as npt
+
+
+SeedType = Union[np.random.RandomState, np.random.Generator, int,
+                 npt.ArrayLike, np.random.SeedSequence]
+ArrayLike0D = Union[bool, int, float, complex, str, bytes, np.generic]
+
+
+__all__: List[str]
+
+
+class Method:
+    @overload
+    def rvs(self, size: None = ...) -> float | int: ...  # type: ignore[misc]
+    @overload
+    def rvs(self, size: int | Tuple[int, ...] = ...) -> np.ndarray: ...
+
+
+class TDRDist(Protocol):
+    @property
+    def pdf(self) -> Callable[..., float]: ...
+    @property
+    def dpdf(self) -> Callable[..., float]: ...
+
+
+class TransformedDensityRejection(Method):
+    def __init__(self,
+                 dist: TDRDist,
+                 mode: None | float = ...,
+                 center: None | float = ...,
+                 params: Tuple[Any, ...] = ...,
+                 domain: None | Tuple[float, float] = ...,
+                 c: float = ...,
+                 cpoints: int = ...,
+                 variant: str = ...,
+                 use_dars: bool = ...,
+                 max_sqhratio: float = ...,
+                 max_intervals: int = ...,
+                 use_center: bool = ...,
+                 use_mode: bool = ...,
+                 guide_factor: float = ...,
+                 seed: SeedType = ...) -> None: ...
+
+    @property
+    def sqhratio(self) -> float: ...
+    @property
+    def n_intervals(self) -> int: ...
+    @property
+    def squeeze_area(self) -> float: ...
+
+    @overload
+    def ppf_hat(self, u: ArrayLike0D) -> float: ...  # type: ignore[misc]
+    @overload
+    def ppf_hat(self, u: npt.ArrayLike) -> np.ndarray: ...
+
+
+class DAUDist(Protocol):
+    @property
+    def pmf(self) -> Callable[..., float]: ...
+
+class DiscreteAliasUrn(Method):
+    def __init__(self,
+                 pv: None | npt.ArrayLike = ...,
+                 dist: None | DAUDist = ...,
+                 params: Tuple[Any, ...] = ...,
+                 domain: None | Tuple[float, float] = ...,
+                 urn_factor: float = ...,
+                 seed: SeedType = ...) -> None: ...

--- a/scipy/stats/_unuran/unuran_wrapper.pyx.templ
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx.templ
@@ -1,0 +1,1078 @@
+# cython: language_level=3
+
+
+# Expression below is replaced by ``DEF NPY_OLD = True`` for NumPy < 1.19
+# and ``DEF NPY_OLD = False`` for NumPy >= 1.19.
+DEF NPY_OLD = isNPY_OLD
+
+
+cimport cython
+from cpython.object cimport PyObject
+cimport numpy as np
+IF not NPY_OLD:
+    from cpython.pycapsule cimport PyCapsule_IsValid, PyCapsule_GetPointer
+    from numpy.random cimport bitgen_t
+ELSE:
+    import copy
+from scipy._lib.ccallback cimport ccallback_t
+from scipy._lib.messagestream cimport MessageStream
+from .unuran cimport *
+import threading
+import numpy as np
+from scipy.stats._distn_infrastructure import argsreduce
+
+
+__all__ = ['UNURANError', 'TransformedDensityRejection', 'DiscreteAliasUrn']
+
+
+cdef extern from "Python.h":
+    PyObject *PyErr_Occurred() nogil
+
+
+# Internal API for handling Python callbacks.
+# TODO: Maybe, support ``LowLevelCallable``s in the future?
+cdef extern from "unuran_callback.h":
+    int init_unuran_callback(ccallback_t *callback, fcn, extra_args) except -1
+    int release_unuran_callback(ccallback_t *callback) except -1
+
+    double pdf_thunk(double x, const unur_distr *distr) nogil
+    double dpdf_thunk(double x, const unur_distr *distr) nogil
+    double cont_cdf_thunk(double x, const unur_distr *distr) nogil
+    double pmf_thunk(int x, const unur_distr *distr) nogil
+    double discr_cdf_thunk(int x, const unur_distr *distr) nogil
+
+    void error_handler(const char *objid, const char *file,
+                       int line, const char *errortype,
+                       int unur_errno, const char *reason) nogil
+
+
+class UNURANError(RuntimeError):
+    pass
+
+
+IF not NPY_OLD:
+    cdef object get_numpy_rng(object seed = None):
+        """
+        Create a NumPy Generator object from a given seed.
+
+        Parameters
+        ----------
+        seed : object, optional
+            Seed for the generator. If None, no seed is set. The seed can be
+            an integer, Generator, RandomState, or SeedSequence.
+
+        Returns
+        -------
+        numpy_rng : object
+            An instance of NumPy's Generator class.
+        """
+        if isinstance(seed, np.random.RandomState):
+            return np.random.default_rng(seed._bit_generator)
+        return np.random.default_rng(seed)
+ELSE:
+    ctypedef double (*URNG_FUNCT)(void *) nogil
+
+    cdef object get_numpy_rng(object seed = None):
+        """
+        Create a NumPy RandomState object from a given seed. If the seed is
+        is an instance of `np.random.Generator`, it is returned as-is.
+
+        Parameters
+        ----------
+        seed : object, optional
+            Seed for the generator. If None, no seed is set. The seed can be
+            an integer, Generator, RandomState, or SeedSequence.
+
+        Returns
+        -------
+        numpy_rng : object
+            An instance of NumPy's RandomState or Generator class.
+        """
+        if seed is None or seed is np.random:
+            return np.random.mtrand._rand
+        if (hasattr(np.random, "Generator") and
+            isinstance(seed, np.random.Generator)):
+            return seed
+        elif isinstance(seed, np.random.RandomState):
+            return seed
+        return np.random.RandomState(seed)
+
+
+@cython.final
+cdef class _URNG:
+    """
+    Build a UNU.RAN's uniform random number generator from a NumPy random
+    numpy generator.
+
+    Parameters
+    ----------
+    numpy_rng : object
+        An instance of NumPy's Generator class. i.e. a NumPy random
+        number generator.
+    """
+    cdef object numpy_rng
+
+    def __init__(self, numpy_rng):
+        self.numpy_rng = numpy_rng
+
+    IF NPY_OLD:
+        cdef double _next_double(self) nogil:
+            # return immediately if an error has occured.
+            if PyErr_Occurred():
+                return 0
+            with gil:
+                return self.numpy_rng.uniform()
+
+    cdef unur_urng * get_urng(self) except *:
+        """
+        Get a ``unur_urng`` object from given ``numpy_rng``.
+
+        Returns
+        -------
+        unuran_urng : unur_urng *
+            A UNU.RAN uniform random number generator.
+        """
+        cdef unur_urng *unuran_urng
+        IF NPY_OLD:
+            unuran_urng = unur_urng_new(<URNG_FUNCT>self._next_double,
+                                        <void *>self)
+            return unuran_urng
+        ELSE:
+            cdef:
+                bitgen_t *numpy_urng
+                const char *capsule_name = "BitGenerator"
+
+            capsule = self.numpy_rng.bit_generator.capsule
+
+            if not PyCapsule_IsValid(capsule, capsule_name):
+                raise ValueError("Invalid pointer to anon_func_state.")
+
+            numpy_urng = <bitgen_t *> PyCapsule_GetPointer(capsule, capsule_name)
+            unuran_urng = unur_urng_new(numpy_urng.next_double,
+                                        <void *>(numpy_urng.state))
+
+            return unuran_urng
+
+
+# Module level lock. This is used to provide thread-safe error reporting.
+# UNU.RAN has a thread-unsafe global FILE streams where errors are reported.
+# To make them thread-safe, one can aquire a lock before calling
+# `unur_set_stream` and release once the stream is not needed anymore.
+cdef object _lock = threading.Lock()
+
+cdef:
+    unur_urng *default_urng
+    object default_numpy_rng
+    _URNG _urng_builder
+
+
+cdef object _setup_unuran():
+    """
+    Sets the default UNU.RAN uniform random number generator and error
+    handler.
+    """
+    global default_urng
+    global default_numpy_rng
+    global _urng_builder
+
+    default_numpy_rng = get_numpy_rng()
+
+    cdef MessageStream _messages = MessageStream()
+
+    _lock.acquire()
+    try:
+        unur_set_stream(_messages.handle)
+        # try to set a default URNG.
+        try:
+            _urng_builder = _URNG(default_numpy_rng)
+            default_urng = _urng_builder.get_urng()
+            if default_urng == NULL:
+                raise UNURANError(_messages.get())
+        except Exception as e:
+            msg = "Failed to initialize the default URNG."
+            raise RuntimeError(msg) from e
+    finally:
+        _lock.release()
+
+    unur_set_default_urng(default_urng)
+    unur_set_error_handler(error_handler)
+
+
+_setup_unuran()
+
+
+cdef dict _unpack_dist(object dist, str dist_type, list meths,
+                       list optional_meths = None):
+    """
+    Get the required methods/attributes from a Python class or object.
+
+    Parameters
+    ----------
+    dist : object
+        An instance of a Python class or object with required methods.
+    dist_type : str
+        Type of the distribution. "cont" for continuous distribution
+        and "discr" for discrete distribution.
+    meths : list
+        A list of methods to get from `dist`.
+    optional_meths : list, optional
+        A list of optional methods to be returned if found. No error
+        is raised if some of the methods in this list are not found.
+
+    Returns
+    -------
+    callbacks : dict
+        A dictionary of callbacks (methods found).
+
+    Raises
+    ------
+    ValueError
+        A ValueError is raised in case some methods in the `meths` list
+        are not found.
+    """
+    cdef dict callbacks = {}
+    for meth in meths:
+        if hasattr(dist, meth):
+            callbacks[meth] = getattr(dist, meth)
+        else:
+            msg = f"`{meth}` required but not found."
+            raise ValueError(msg)
+    if optional_meths is not None:
+        for meth in optional_meths:
+            if hasattr(dist, meth):
+                callbacks[meth] = getattr(dist, meth)
+    return callbacks
+
+
+cdef void _pack_distr(unur_distr *distr, dict callbacks) except *:
+    """
+    Set the methods of a continuous or discrete distribution object
+    using a dictionary of callbacks.
+
+    Parameters
+    ----------
+    distr : unur_distr *
+        A continuous or discrete distribution object.
+    callbacks : dict
+        A dictionary of callbacks.
+    """
+    if unur_distr_is_cont(distr):
+        if "pdf" in callbacks:
+            unur_distr_cont_set_pdf(distr, pdf_thunk)
+        if "dpdf" in callbacks:
+            unur_distr_cont_set_dpdf(distr, dpdf_thunk)
+        if "cdf" in callbacks:
+            unur_distr_cont_set_cdf(distr, cont_cdf_thunk)
+    else:
+        if "pmf" in callbacks:
+            unur_distr_discr_set_pmf(distr, pmf_thunk)
+        if "cdf" in callbacks:
+            unur_distr_discr_set_cdf(distr, discr_cdf_thunk)
+
+
+def _validate_domain(domain):
+    if domain is not None:
+        # UNU.RAN doesn't recognize nans in the probability vector
+        # and throws an "unknown error". Hence, check for nans ourselves
+        if np.isnan(domain).any():
+            raise ValueError("`domain` must contain only non-nan values.")
+        # Length of the domain must be exactly 2.
+        if len(domain) != 2:
+            raise ValueError("`domain` must be a length 2 tuple.")
+        # Throw an error here if it can't converted into a tuple.
+        domain = tuple(domain)
+    return domain
+
+
+cdef double[::1] _validate_pv(pv) except *:
+    cdef double[::1] pv_view = None
+    if pv is not None:
+        # Make sure the PV is a contiguous array of doubles.
+        pv = pv_view = np.ascontiguousarray(pv, dtype=np.float64)
+        # Empty arrays not allowed.
+        if pv.size == 0:
+            raise ValueError("`pv` must have at least one element.")
+        # NaNs and infs not recognized by UNU.RAN so throw an error here
+        # only.
+        if not np.isfinite(pv).all():
+            raise ValueError("`pv` must contain only finite / non-nan "
+                             "values.")
+        # This special case is not handled by UNU.RAN and it just throws
+        # an "unknown error".
+        if (pv == 0).all():
+            raise ValueError("`pv` must contain at least one non-zero "
+                             "value.")
+    # return a contiguous memory view of the PV
+    return pv_view
+
+
+cdef class Method:
+    """
+    A base class for all the wrapped generators.
+
+    There are 5 basic functions of this base class:
+
+    * It provides a `_set_rng` method to initialize and set a `unur_gen`
+      object. It should be called during the setup stage in the `__cinit__`
+      method. As it uses MessageStream, the call must be protected under
+      the module-level lock.
+    * `_check_errorcode` must be called after calling a UNU.RAN function
+      that returns a error code. It raises an error if Python error variable
+      has been set or if an error has occured in UNU.RAN.
+    * It implements the `rvs` public method for sampling. No inheriting class
+      should override this method.
+    * Provides the `seed` property to get and set the NumPy URNG.
+    * Implements the __dealloc__ method. The inheriting class must not overide
+      this method.
+
+    """
+    cdef unur_distr *distr
+    cdef unur_par *par
+    cdef unur_gen *rng
+    cdef unur_urng *urng
+    cdef object numpy_rng
+    cdef _URNG _urng_builder
+    cdef object callbacks
+    cdef object _callback_wrapper
+    cdef object params
+    cdef MessageStream _messages
+
+    cdef inline void _check_errorcode(self, int errorcode) except *:
+        # check for non-zero errorcode
+        if errorcode != UNUR_SUCCESS:
+            # check if the Python error variable has been set. We need
+            # to do this because it is possible that an error has occured
+            # during a call to the callback. As we can't perform a non-local
+            # return (because that leads to memory leaks), there is no way
+            # to know whether a callback has errored out until a non-zero
+            # errorcode has been returned by UNU.RAN.
+            if PyErr_Occurred():
+                return
+            msg = self._messages.get()
+            if msg:
+                raise UNURANError(msg)
+
+    cdef inline void _set_rng(self, object seed) except *:
+        """
+        Create a UNU.RAN random number generator.
+
+        Parameters
+        ----------
+        seed : object
+            Seed for the uniform random number generator. Can be a integer,
+            NumPy BitGenerator, RandomState, or SeedSequence.
+        par : unur_par *
+            UNU.RAN parameter object.
+        distr : unur_distr *
+            UNU.RAN distribution object.
+        """
+        self.numpy_rng = get_numpy_rng(seed)
+        self._urng_builder = _URNG(self.numpy_rng)
+        self.urng = self._urng_builder.get_urng()
+        if self.urng == NULL:
+            msg = self._messages.get()
+            if PyErr_Occurred():
+                return
+            raise UNURANError(msg)
+        self._check_errorcode(unur_set_urng(self.par, self.urng))
+        self.rng = unur_init(self.par)
+        # set self.par = NULL because a call to `unur_init` destroys
+        # the parameter object. See "Creating a generator object" in
+        # http://statmath.wu.ac.at/software/unuran/doc/unuran.html#Concepts
+        self.par = NULL
+        if self.rng == NULL:
+            msg = self._messages.get()
+            if PyErr_Occurred():
+                return
+            raise UNURANError(msg)
+        unur_distr_free(self.distr)
+        self.distr = NULL
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cdef inline void _rvs_cont(self, double[::1] out) except *:
+        """
+        Sample random variates from a continuous distribution.
+
+        Parameters
+        ----------
+        out : double[::1]
+            A memory view of size ``size`` to store the result.
+        """
+        cdef:
+            ccallback_t callback
+            unur_gen *rng = self.rng
+            size_t i
+            size_t size = len(out)
+
+        if self._callback_wrapper is not None:
+            init_unuran_callback(&callback, self._callback_wrapper,
+                                 self.params)
+        _lock.acquire()
+        try:
+            self._messages.clear()
+            unur_set_stream(self._messages.handle)
+
+            for i in range(size):
+                out[i] = unur_sample_cont(rng)
+
+            msg = self._messages.get()
+            if PyErr_Occurred():
+                return
+            if msg:
+                raise UNURANError(msg)
+        finally:
+            _lock.release()
+            if self._callback_wrapper is not None:
+                release_unuran_callback(&callback)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cdef inline void _rvs_discr(self, int[::1] out) except *:
+        """
+        Sample random variates from a discrete distribution.
+
+        Parameters
+        ----------
+        out : int[::1]
+            A memory view of size ``size`` to store the result.
+        """
+        cdef:
+            ccallback_t callback
+            unur_gen *rng = self.rng
+            size_t i
+            size_t size = len(out)
+
+        if self._callback_wrapper is not None:
+            init_unuran_callback(&callback, self._callback_wrapper,
+                                 self.params)
+        _lock.acquire()
+        try:
+            self._messages.clear()
+            unur_set_stream(self._messages.handle)
+
+            for i in range(size):
+                out[i] = unur_sample_discr(rng)
+
+            msg = self._messages.get()
+            if PyErr_Occurred():
+                return
+            if msg:
+                raise UNURANError(msg)
+        finally:
+            _lock.release()
+            if self._callback_wrapper is not None:
+                release_unuran_callback(&callback)
+
+    def rvs(self, size=None):
+        """
+        Sample from the distribution.
+
+        Parameters
+        ----------
+        size : int or tuple, optional
+            The shape of samples. Default is ``None`` in which case a scalar
+            sample is returned.
+
+        Returns
+        -------
+        rvs : array_like
+            A NumPy array of random variates.
+        """
+        cdef double[::1] out_cont
+        cdef int[::1] out_discr
+        N = 1 if size is None else np.prod(size)
+        if unur_distr_is_cont(unur_get_distr(self.rng)):
+            out_cont = np.empty(N, dtype=np.float64)
+            self._rvs_cont(out_cont)
+            if size is None:
+                return out_cont[0]
+            return np.asarray(out_cont).reshape(size)
+        elif unur_distr_is_discr(unur_get_distr(self.rng)):
+            out_discr = np.empty(N, dtype=np.int32)
+            self._rvs_discr(out_discr)
+            if size is None:
+                return out_discr[0]
+            return np.asarray(out_discr).reshape(size)
+        else:
+            raise NotImplementedError("only univariate continuous and "
+                                      "discrete distributions supported")
+
+    @property
+    def seed(self):
+        return self.numpy_rng
+
+    @seed.setter
+    def seed(self, new_seed):
+        self.numpy_rng = get_numpy_rng(new_seed)
+        with _lock:
+            self._messages.clear()
+            unur_set_stream(self._messages.handle)
+            unur_urng_free(self.urng)
+            self._urng_builder = _URNG(self.numpy_rng)
+            self.urng = self._urng_builder.get_urng()
+            if self.urng == NULL:
+                raise UNURANError(self._messages.get())
+            unur_chg_urng(self.rng, self.urng)
+
+    @cython.final
+    def __dealloc__(self):
+        if self.distr != NULL:
+            unur_distr_free(self.distr)
+            self.distr = NULL
+        if self.par != NULL:
+            unur_par_free(self.par)
+            self.par = NULL
+        if self.rng != NULL:
+            unur_free(self.rng)
+            self.rng = NULL
+        if self.urng != NULL:
+            unur_urng_free(self.urng)
+            self.urng = NULL
+
+
+cdef class TransformedDensityRejection(Method):
+    r"""
+    Transformed Density Rejection (TDR) Method.
+
+    TDR is an acceptance/rejection method that uses the concavity of a
+    transformed density to construct hat function and squeezes automatically.
+    Most universal algorithms are very slow compared to algorithms that are
+    specialized to that distribution. Algorithms that are fast have a slow
+    setup and require large tables. The aim of this universal method is to
+    provide an algorithm that is not too slow and needs only a short setup.
+    This method can be applied to continuous unimodal distributions with
+    T-concave density function. See [1]_ and [2]_ for more details.
+
+    Parameters
+    ----------
+    dist : object
+        An instance of a class with 'pdf' and 'dpdf' methods.
+
+        * 'pdf': PDF of the distribution. The signature of the PDF is
+          expected to be: ``def pdf(x: float, *params) -> float``. i.e.
+          the PDF should accept a Python float and the parameters and
+          return a Python float. It doesn't need to integrate to 1 i.e.
+          the PDF doesn't need to be normalized.
+        * 'dpdf': Derivative of the PDF w.r.t x (i.e. the variate). Must
+          have the same signature as the PDF.
+
+    mode : float, optional
+        Mode of the distribution. It is optional and only required if
+        `use_mode` is ``True``.
+    center : float, optional
+        Center (``loc``) of the distribution. It is optional and only
+        required if `use_center` is ``True``. Default is 0.
+    params : tuple, optional
+        Parameters that the PDF and DPDF take. Default is an empty tuple.
+    domain : list or tuple of length 2, optional
+        The support of the distribution. Must not contain `nan` values.
+        Default is ``None``. When ``None``, the support is assumed to be
+        :math:`(-\infty, \infty)`.
+    c : float, optional
+        The transformation function. See Notes for the allowed values for
+        this parameter and their interpretation. Default is -0.5.
+    cpoints : int, optional
+        The number of construction points. Default is 30.
+    variant : str, optional
+        The variant to use. Available options are:
+
+          * 'ps': PS variant (Default)
+          * 'gw': GW variant
+          * 'ia': IA variant
+
+        See Notes for their explainations.
+    use_dars : bool, optional
+        If True, "derandomized adaptive rejection sampling" (DARS) is used
+        in setup. See [1]_ for the details of the DARS algorithm. Default
+        is True.
+    max_sqhratio : float, optional
+        Set upper bound for the ratio (area below squeeze) / (area below hat).
+        It must be a number between 0 and 1. Default is 0.99.
+    max_intervals : int, optional
+        Set maximum number of intervals. Default is 100.
+    use_center : bool, optional
+        Use the center as construction point, if given. Default is True.
+    use_mode : bool, optional
+        Use the (exact!) mode as construction point, if given. Default is
+        True.
+    guide_factor : float, optional
+        Set factor for relative size of the guide table for indexed search.
+        It must be greater than or equal to 0. When set to 0, then sequential
+        search is used. Default is 2.
+    seed : int, BitGenerator, Generator, RandomState, SeedSequence, optional
+        Seed for the underlying uniform random number generation.
+
+    Notes
+    -----
+    The transformation of the PDF must be concave in order to
+    construct the hat function. Such a PDF is called T-concave. Currently
+    the following transformations are supported:
+
+    .. math::
+
+        c = 0.: T(x) &= \log(x)\\
+        c = -0.5: T(x) &= \frac{1}{\sqrt{x}} \text{ (Default)}
+
+    Three variants of this method are available:
+
+    * GW: squeezes between construction points.
+    * PS: squeezes proportional to hat function. (Default)
+    * IA: same as variant PS but uses a compositon method with
+      "immediate acceptance" in the region below the squeeze.
+
+    
+    References
+    ----------
+    .. [1] UNU.RAN reference manual, Section 5.3.16,
+           "TDR - Transformed Density Rejection",
+           http://statmath.wu.ac.at/software/unuran/doc/unuran.html#TDR
+    .. [2] Hörmann, Wolfgang. "A rejection technique for sampling from
+           T-concave distributions." ACM Transactions on Mathematical
+           Software (TOMS) 21.2 (1995): 182-193
+    .. [3] W.R. Gilks and P. Wild (1992). Adaptive rejection sampling for
+           Gibbs sampling, Applied Statistics 41, pp. 337-348.
+
+    Examples
+    --------
+    >>> from scipy.stats import TransformedDensityRejection
+
+    Suppose we have a density:
+
+    .. math::
+
+        f(x) = \begin{cases}
+                1 - x^2,  &  -1 \leq x \leq 1 \\
+                0,        &  \text{otherwise}
+               \end{cases}
+
+    The derivative of this density function is:
+
+    .. math::
+
+        \frac{df(x)}{dx} = \begin{cases}
+                            -2x,  &  -1 \leq x \leq 1 \\
+                            0,    &  \text{otherwise}
+                           \end{cases}
+
+    Notice that the PDF doesn't integrate to 1. As this is a rejection based
+    method, we need not have a normalized PDF. To initialize the generator,
+    we can use:
+
+    >>> urng = np.random.default_rng()
+    >>> class MyDist:
+    ...     def pdf(self, x):
+    ...         return 1-x*x
+    ...     def dpdf(self, x):
+    ...         return -2*x
+    ... 
+    >>> dist = MyDist()
+    >>> rng = TransformedDensityRejection(dist, domain=(-1, 1), seed=urng)
+
+    Now, we can use the `rvs` method to generate samples from the
+    distribution:
+
+    >>> rvs = rng.rvs(1000)
+
+    To use the log transformation with 10 construction points and the
+    immediate acceptance variant of the method, do:
+
+    >>> rng = TransformedDensityRejection(dist, domain=(-1, 1), c=0.,
+    ...                                   cpoints=10, variant='ia', seed=urng)
+    >>> rvs = rng.rvs(1000)
+    """
+    def __cinit__(self,
+                  dist,
+                  mode=None,
+                  center=None,
+                  params=(),
+                  domain=None,
+                  c=-0.5,
+                  cpoints=30,
+                  variant="ps",
+                  use_dars=True,
+                  max_sqhratio=0.99,
+                  max_intervals=100,
+                  use_center=True,
+                  use_mode=True,
+                  guide_factor=2,
+                  seed=None):
+        cdef double[::1] cpoints_array
+        (params, domain, c, cpoints, cpoints_array,
+         variant) = self._validate_args(params, domain, c, cpoints, variant)
+
+        cdef:
+            unur_distr *distr
+            unur_par *par
+            unur_gen *rng
+            ccallback_t callback
+
+        self.callbacks = _unpack_dist(dist, "cont", meths=["pdf", "dpdf"])
+        self.params = params
+        def _callback_wrapper(x, name, *args):
+            return self.callbacks[name](x, *args)
+        self._callback_wrapper = _callback_wrapper
+        init_unuran_callback(&callback, self._callback_wrapper, self.params)
+        self._messages = MessageStream()
+        _lock.acquire()
+        try:
+            unur_set_stream(self._messages.handle)
+
+            self.distr = unur_distr_cont_new()
+            if self.distr == NULL:
+                raise UNURANError(self._messages.get())
+            _pack_distr(self.distr, self.callbacks)
+
+            if mode is not None:
+                self._check_errorcode(unur_distr_cont_set_mode(self.distr, mode))
+            if center is not None:
+                self._check_errorcode(unur_distr_cont_set_center(self.distr, center))
+
+            if domain is not None:
+                self._check_errorcode(unur_distr_cont_set_domain(self.distr, domain[0],
+                                                                 domain[1]))
+
+            self.par = unur_tdr_new(self.distr)
+            if self.par == NULL:
+                raise UNURANError(self._messages.get())
+            self._check_errorcode(unur_tdr_set_c(self.par, c))
+            if cpoints_array is None:
+                self._check_errorcode(unur_tdr_set_cpoints(self.par, cpoints, NULL))
+            else:
+                self._check_errorcode(unur_tdr_set_cpoints(self.par, len(cpoints_array),
+                                                           &cpoints_array[0]))
+
+            if variant == "ps":
+                self._check_errorcode(unur_tdr_set_variant_ps(self.par))
+            elif variant == "ia":
+                self._check_errorcode(unur_tdr_set_variant_ia(self.par))
+            elif variant == "gw":
+                self._check_errorcode(unur_tdr_set_variant_gw(self.par))
+
+            self._check_errorcode(unur_tdr_set_usedars(self.par, use_dars))
+            self._check_errorcode(unur_tdr_set_max_sqhratio(self.par, max_sqhratio))
+            self._check_errorcode(unur_tdr_set_max_intervals(self.par, max_intervals))
+            self._check_errorcode(unur_tdr_set_usecenter(self.par, use_center))
+            self._check_errorcode(unur_tdr_set_usemode(self.par, use_mode))
+
+            self._set_rng(seed)
+        finally:
+            release_unuran_callback(&callback)
+            _lock.release()
+
+    cdef object _validate_args(self, params, domain, c, cpoints, variant):
+        cdef double[::1] cpoints_array = None
+        domain = _validate_domain(domain)
+        if np.isnan(c):
+            raise ValueError("`c` must be a non-nan value.")
+        if variant not in {"ps", "gw", "ia"}:
+            raise ValueError("Invalid option for the `variant`.")
+        if not np.isscalar(cpoints):
+            cpoints_array = np.ascontiguousarray(cpoints, dtype=np.float64)
+            if len(cpoints_array) == 0:
+                raise ValueError("`cpoints` must either be a scalar or a "
+                                 "non-empty array.")
+
+        params = tuple(params)
+
+        return params, domain, c, cpoints, cpoints_array, variant
+
+    @property
+    def sqhratio(self):
+        """
+        Get the current ratio (area below squeeze) / (area below hat) for the
+        generator.
+        """
+        return unur_tdr_get_sqhratio(self.rng)
+
+    @property
+    def hat_area(self):
+        """Get the area below the hat for the generator."""
+        return unur_tdr_get_hatarea(self.rng)
+
+    @property
+    def squeeze_area(self):
+        """Get the area below the squeeze for the generator."""
+        return unur_tdr_get_squeezearea(self.rng)
+
+    cdef inline void _ppf_hat(self, const double *u, double *out, size_t N) except *:
+        cdef:
+            ccallback_t callback
+            size_t i
+        init_unuran_callback(&callback, self._callback_wrapper, self.params)
+        _lock.acquire()
+        try:
+            self._messages.clear()
+            unur_set_stream(self._messages.handle)
+            for i in range(N):
+                out[i] = unur_tdr_eval_invcdfhat(self.rng, u[i], NULL, NULL, NULL)
+            msg = self._messages.get()
+            if msg:
+                raise UNURANError(msg)
+        finally:
+            _lock.release()
+            release_unuran_callback(&callback)
+
+    def ppf_hat(self, u):
+        """
+        Evaluate the inverse of the CDF of the hat distribution at u.
+
+        This call does not work for variant IA (immediate acceptance).
+        In this case the hat CDF is evaluated as if variant PS is used.
+
+        Parameters
+        ----------
+        u : array_like
+            An array of percentiles
+
+        Returns
+        -------
+        ppf_hat : array_like
+            Array of quantiles corresponding to the given percentiles.
+
+        Examples
+        --------
+        >>> from scipy.stats import TransformedDensityRejection
+        >>> from scipy.stats import norm
+        >>> from math import exp
+        >>> 
+        >>> class MyDist:
+        ...     def pdf(self, x):
+        ...         return exp(-0.5 * x**2)
+        ...     def dpdf(self, x):
+        ...         return -x * exp(-0.5 * x**2)
+        ... 
+        >>> dist = MyDist()
+        >>> rng = TransformedDensityRejection(dist, seed=123)
+        >>> 
+        >>> rng.ppf_hat(0.5)
+        -0.00018050266342393984
+        >>> norm.ppf(0.5)
+        0.0
+        >>> u = np.linspace(0, 1, num=1000)
+        >>> ppf_hat = rng.ppf_hat(u)
+        """
+        u = np.asarray(u, dtype='d')
+        oshape = u.shape
+        u = u.ravel()
+        # UNU.RAN fills in ends of the support when u < 0 or u > 1 while
+        # SciPy fills in nans. Prefer SciPy behaviour.
+        cond0 = 0 <= u
+        cond1 = u <= 1
+        cond2 = cond0 & cond1
+        # UNU.RAN fails to recognize NaNs and seg faults when nans are
+        # present. So, handle nan manually.
+        cond3 = np.isnan(u)
+        goodu = argsreduce(cond2, u)[0]
+        out = np.empty_like(u)
+        cdef double[::1] u_view = np.ascontiguousarray(goodu)
+        cdef double[::1] goodout = np.empty_like(u_view)
+        if cond2.any():
+            self._ppf_hat(&u_view[0], &goodout[0], len(goodu))
+        np.place(out, cond2, goodout)
+        np.place(out, ~cond2 | cond3, np.nan)
+        return np.asarray(out).reshape(oshape)[()]
+
+
+cdef class DiscreteAliasUrn(Method):
+    r"""
+    Discrete Alias-Urn Method.
+
+    This method is used to sample from discrete distributions with a finite
+    domain. It uses the probability vector of size :math:`N` or a probability
+    mass function with a finite support to generator random numbers from the
+    distribution.
+
+    Parameters
+    ----------
+    pv : array_like, optional
+        Probability vector (PV) of the distribution. If PV isn't available,
+        PMF of the distribution is expected.
+    dist : object, optional
+        An instance of a class with a 'pmf' method. Only required if PV isn't
+        available. The signature of the PMF is expected to be:
+        ``def pmf(k: int, *params) -> float``. i.e it should accecpt a Python
+        integer and return a Python float.
+    params : tuple, optional
+        Parameters that the PMF takes. If a probability vector is available,
+        this parameter is ignored. Default is an empty tuple.
+    domain : int, optional
+        Support of the PMF. If a probability vector is not available, a
+        finite domain must be given. i.e. the PMF must have a finite support.
+    urnfactor : float, optional
+        Size of the urn table *relative* to the size of the probability
+        vector. It must not be less than 1. Larger tables result is faster
+        generation times but require a more expensive setup.
+    seed : int, BitGenerator, Generator, RandomState, SeedSequence, optional
+        Seed for the underlying uniform random number generation.
+
+    Notes
+    -----
+    This method works when either a finite probability vector is available or
+    the PMF of the distribution is available. In case a PMF is only available,
+    the *finite* support (domain) of the PMF must also be given. It is
+    recommended to first obtain the probability vector by evaluating the PMF
+    at each point in the support and then using it instead.
+
+    If a probability vector is given, it must be a 1-dimensional array of
+    non-negative floats without any ``inf`` or ``nan`` values. Also, there
+    must be at least one non-zero entry otherwise an exception is raised.
+
+    The parameter ``urn_factor`` can be increased for faster generation at the
+    cost of increased setup time. This method uses a table for random
+    variate generation. ``urn_factor`` controls the size of this table
+    relative to the size of the probability vector (or width of the support,
+    in case a PV is not available). As this table is computed during setup
+    time, increasing this parameter linearly increases the time required to
+    setup. It is recommended to keep this parameter under 2.
+
+    References
+    ----------
+    .. [1] UNU.RAN reference manual, Section 5.8.2,
+           "DAU - (Discrete) Alias-Urn method",
+           http://statmath.wu.ac.at/software/unuran/doc/unuran.html#DAU
+    .. [2] A.J. Walker (1977). An efficient method for generating discrete
+           random variables with general distributions, ACM Trans. Math.
+           Software 3, pp. 253-256.
+
+    Examples
+    --------
+    >>> from scipy.stats import DiscreteAliasUrn
+
+    To create a random number generator using a probability vector, use:
+
+    >>> pv = [0.1, 0.3, 0.6]
+    >>> urng = np.random.default_rng()
+    >>> rng = DiscreteAliasUrn(pv, seed=urng)
+
+    The RNG has been setup. Now, we can now use the `rvs` method to
+    generate samples from the distribution:
+
+    >>> rvs = rng.rvs(size=1000)
+
+    To verify that the random variates follow the given distribution, we can
+    use the chi-squared test (as a measure of goodness-of-fit):
+
+    >>> from scipy.stats import chisquare
+    >>> _, freqs = np.unique(rvs, return_counts=True)
+    >>> freqs = freqs / np.sum(freqs)
+    >>> chisquare(freqs, pv).pvalue
+    0.9993602047563164
+
+    As the p-value is very high, we fail to reject the null hypothesis that
+    the observed frequencies are same as the expected frequencies. Hence,
+    we can safely assume that the variates have been generated from the given
+    distribution. Note that this just gives the correctness of the algorithm
+    and not the quality of the samples.
+
+    If a PV is not available, an instance of a class with a PMF method and a
+    finite domain can also be passed.
+
+    >>> urng = np.random.default_rng()
+    >>> class Binomial:
+    ...     def __init__(self, n, p):
+    ...         self.n = n
+    ...         self.p = p
+    ...     def pmf(self, x):
+    ...         # note that the pmf doesn't need to be normalized.
+    ...         return self.p**x * (1-self.p)**(self.n-x)
+    ... 
+    >>> n, p = 10, 0.2
+    >>> dist = Binomial(n, p)
+    >>> domain = 0, n
+    >>> rng = DiscreteAliasUrn(dist=dist, domain=domain, seed=urng)
+
+    Now, we can sample from the distribution using the `rvs` method
+    and also measure the goodness-of-fit of the samples:
+
+    >>> rvs = rng.rvs(1000)
+    >>> _, freqs = np.unique(rvs, return_counts=True)
+    >>> freqs = freqs / np.sum(freqs)
+    >>> obs_freqs = np.zeros(11)  # some frequencies may be zero.
+    >>> obs_freqs[:freqs.size] = freqs
+    >>> pv = [dist.pmf(i) for i in range(0, 11)]
+    >>> # Correct for some numerical error
+    >>> pv = np.asarray(pv) / np.sum(pv)
+    >>> chisquare(obs_freqs, pv).pvalue
+    0.9999999999999999
+
+    To set the ``urn_factor``, use:
+
+    >>> rng = DiscreteAliasUrn(pv, urn_factor=2, seed=urng)
+
+    This uses a table twice the size of the probability vector to generate
+    random variates from the distribution.
+    """
+    def __cinit__(self,
+                  pv=None,
+                  dist=None,
+                  params=(),
+                  domain=None,
+                  urn_factor=1,
+                  seed=None):
+        cdef double[::1] pv_view
+        (pv_view, params, domain) = self._validate_args(pv, dist, params, domain)
+
+        cdef:
+            unur_distr *distr
+            unur_par *par
+            unur_gen *rng
+
+        self._messages = MessageStream()
+        _lock.acquire()
+        try:
+            unur_set_stream(self._messages.handle)
+
+            self.distr = unur_distr_discr_new()
+            if self.distr == NULL:
+                raise UNURANError(self._messages.get())
+
+            n_pv = len(pv_view)
+            self._check_errorcode(unur_distr_discr_set_pv(self.distr, &pv_view[0], n_pv))
+
+            if domain is not None:
+                self._check_errorcode(unur_distr_discr_set_domain(self.distr, domain[0],
+                                                                  domain[1]))
+
+            self.par = unur_dau_new(self.distr)
+            if self.par == NULL:
+                raise UNURANError(self._messages.get())
+            self._check_errorcode(unur_dau_set_urnfactor(self.par, urn_factor))
+
+            self._set_rng(seed)
+        finally:
+            _lock.release()
+
+    cdef object _validate_args(self, pv, dist, params, domain):
+        cdef double[::1] pv_view
+
+        params = tuple(params)
+
+        if domain is not None:
+            domain = _validate_domain(domain)
+            if not np.isfinite(domain).all():
+                raise ValueError("`domain` must be finite.")
+        else:
+            if dist is not None:
+                raise ValueError("`domain` must be provided if "
+                                 "`pv` is not available.")
+        if pv is None:
+            if dist is None:
+                raise ValueError("Either a `pv` or a `dist` object with a "
+                                 "PMF method required but none given.")
+            if not hasattr(dist, "pmf"):
+                raise ValueError("`pmf` required but not found.")
+            # we assume the PMF to accept and return floats. So, we need
+            # to vectorize it to call with an array of points in the domain.
+            pmf = np.vectorize(dist.pmf)
+            k = np.arange(domain[0], domain[1]+1)
+            pv = pmf(k, *params)
+            try:
+                pv_view = _validate_pv(pv)
+            except ValueError as err:
+                msg = "PMF returned invalid values: " + err.args[0]
+                raise ValueError(msg) from None
+        else:
+            pv_view = _validate_pv(pv)
+
+        return pv_view, params, domain

--- a/scipy/stats/setup.py
+++ b/scipy/stats/setup.py
@@ -78,6 +78,9 @@ def configuration(parent_package='', top_path=None):
     )
     ext._pre_build_hook = pre_build_hook
 
+    # add unuran subumodule
+    config.add_subpackage('_unuran')
+
     # add boost stats distributions
     config.add_subpackage('_boost')
 

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1,0 +1,593 @@
+import threading
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal, suppress_warnings
+from numpy.lib import NumpyVersion
+from scipy.stats import TransformedDensityRejection, DiscreteAliasUrn
+from scipy.stats import UNURANError
+from scipy import stats
+from scipy.stats import chisquare, cramervonmises
+from scipy.stats._distr_params import distdiscrete
+
+
+# common test data: this data can be shared between all the tests.
+
+
+# Normal distribution shared between all the continuous methods
+class common_cont_dist:
+    # Private methods are used for performance. Public methods do a lot of
+    # validations and expensive numpy operations (like broadcasting), hence,
+    # slowing down some of the methods significantly. We can use private
+    # methods as we know that the data is guaranteed to be inside the domain
+    # and a scalar (so, no masking bad values and broadcasting required).
+    pdf = stats.norm._pdf
+    dpdf = lambda x: -x * stats.norm._pdf(x)
+    cdf = stats.norm._cdf
+
+
+# A binomial distribution to share between all the discrete methods
+class common_discr_dist:
+    params = (10, 0.2)
+    pmf = stats.binom._pmf
+    cdf = stats.binom._cdf
+
+
+all_methods = [
+    ("TransformedDensityRejection", {"dist": common_cont_dist}),
+    ("DiscreteAliasUrn", {"pv": [0.02, 0.18, 0.8]})
+]
+
+
+bad_pdfs_common = [
+    # Negative PDF
+    (lambda x: -x, UNURANError, r"50 : PDF\(x\) < 0.!"),
+    # Returning wrong type
+    (lambda x: [], TypeError, r"must be real number, not list"),
+    # Undefined name inside the function
+    (lambda x: foo, NameError, r"name 'foo' is not defined"),  # type: ignore[name-defined]
+    # Infinite value returned => Overflow error.
+    (lambda x: np.inf, UNURANError, r"50 : PDF\(x\) overflow"),
+    # NaN value => internal error in UNU.RAN
+    # Currently, UNU.RAN just returns a "cannot create bounded hat!"
+    # error which is not very useful. So, instead of testing the error
+    # message, we just ensure an error is raised.
+    (lambda x: np.nan, UNURANError, r"..."),
+    # signature of PDF wrong
+    (lambda: 1.0, TypeError, r"takes 0 positional arguments but 1 was given")
+]
+
+bad_dpdf_common = [
+    # Infinite value returned. For dPDF, UNU.RAN complains that it cannot
+    # create a bounded hat instead of an overflow error.
+    (lambda x: np.inf, UNURANError, r"51 : cannot create bounded hat"),
+    # NaN value => internal error in UNU.RAN
+    # Currently, UNU.RAN just returns a "cannot create bounded hat!"
+    # error which is not very useful. So, instead of testing the error
+    # message, we just ensure an error is raised.
+    (lambda x: np.nan, UNURANError, r"..."),
+    # Returning wrong type
+    (lambda x: [], TypeError, r"must be real number, not list"),
+    # Undefined name inside the function
+    (lambda x: foo, NameError, r"name 'foo' is not defined"),  # type: ignore[name-defined]
+    # signature of dPDF wrong
+    (lambda: 1.0, TypeError, r"takes 0 positional arguments but 1 was given")
+]
+
+bad_pmf_common = [
+    # UNU.RAN fails to validate float inf, nan values returned
+    # by the PMF and throws an unhelpful "unknown error". One
+    # helpful thing to do here is to calculate the PV ourselves
+    # and check for inf, nan, if the domain is known and distribution
+    # doesn't have infinite tails.
+    (lambda x: np.inf, UNURANError, r"240 : unknown error"),
+    (lambda x: np.nan, UNURANError, r"240 : unknown error"),
+    (lambda x: 0.0, UNURANError, r"240 : unknown error"),
+    # Undefined name inside the function
+    (lambda x: foo, NameError, r"name 'foo' is not defined"),  # type: ignore[name-defined]
+    # Returning wrong type
+    (lambda x: [], TypeError, r"must be real number, not list"),
+    # probabilities < 0
+    (lambda x: -x, UNURANError, r"50 : probability < 0"),
+    # signature of PMF wrong
+    (lambda: 1.0, TypeError, r"takes 0 positional arguments but 1 was given")
+]
+
+bad_pv_common = [
+    ([], r"must have at least one element"),
+    ([[1.0, 0.0]], r"wrong number of dimensions \(expected 1, got 2\)"),
+    ([0.2, 0.4, np.nan, 0.8], r"must contain only finite / non-nan values"),
+    ([0.2, 0.4, np.inf, 0.8], r"must contain only finite / non-nan values"),
+    ([0.0, 0.0], r"must contain at least one non-zero value"),
+]
+
+
+# size of the domains is incorrect
+bad_sized_domains = [
+    # > 2 elements in the domain
+    ((1, 2, 3), ValueError, r"must be a length 2 tuple"),
+    # empty domain
+    ((), ValueError, r"must be a length 2 tuple")
+]
+
+# domain values are incorrect
+bad_domains = [
+    ((2, 1), UNURANError, r"left >= right"),
+    ((1, 1), UNURANError, r"left >= right"),
+]
+
+# infinite and nan values present in domain.
+inf_nan_domains = [
+    # left >= right
+    ((10, 10), UNURANError, r"left >= right"),
+    ((np.inf, np.inf), UNURANError, r"left >= right"),
+    ((-np.inf, -np.inf), UNURANError, r"left >= right"),
+    ((np.inf, -np.inf), UNURANError, r"left >= right"),
+    # Also include nans in some of the domains.
+    ((-np.inf, np.nan), ValueError, r"only non-nan values"),
+    ((np.nan, np.inf), ValueError, r"only non-nan values")
+]
+
+# `nan` values present in domain. Some distributions don't support
+# infinite tails, so don't mix the nan values with infinities.
+nan_domains = [
+    ((0, np.nan), ValueError, r"only non-nan values"),
+    ((np.nan, np.nan), ValueError, r"only non-nan values")
+]
+
+
+# all the methods should throw errors for nan, bad sized, and bad valued
+# domains.
+@pytest.mark.parametrize("domain, err, msg",
+                         bad_domains + bad_sized_domains + nan_domains)  # type: ignore[operator]
+@pytest.mark.parametrize("method, kwargs", all_methods)
+def test_bad_domain(domain, err, msg, method, kwargs):
+    Method = getattr(stats, method)
+    with pytest.raises(err, match=msg):
+        Method(**kwargs, domain=domain)
+
+
+@pytest.mark.parametrize("method, kwargs", all_methods)
+def test_seed(method, kwargs):
+    Method = getattr(stats, method)
+
+    # simple seed that works for any version of NumPy
+    seed = 123
+    rng1 = Method(**kwargs, seed=seed)
+    rng2 = Method(**kwargs, seed=seed)
+    assert_equal(rng1.rvs(100), rng2.rvs(100))
+
+    # RandomState seed for old numpy
+    if NumpyVersion(np.__version__) < '1.19.0':
+        seed1 = np.random.RandomState(123)
+        seed2 = 123
+        rng1 = Method(**kwargs, seed=seed1)
+        rng2 = Method(**kwargs, seed=seed2)
+        assert_equal(rng1.rvs(100), rng2.rvs(100))
+        rvs11 = rng1.rvs(550)
+        rvs12 = rng1.rvs(50)
+        rvs2 = rng2.rvs(600)
+        assert_equal(rvs11, rvs2[:550])
+        assert_equal(rvs12, rvs2[550:])
+    else:  # Generator seed for new NumPy
+        seed1 = np.random.default_rng(123)
+        seed2 = np.random.PCG64(123)
+        rng1 = Method(**kwargs, seed=seed1)
+        rng2 = Method(**kwargs, seed=seed2)
+        assert_equal(rng1.rvs(100), rng2.rvs(100))
+
+        # when a RandomState is given, it should take the bitgen_t
+        # member of the class and create a Generator instance.
+        seed1 = np.random.RandomState(np.random.MT19937(123))
+        seed2 = np.random.Generator(np.random.MT19937(123))
+        rng1 = Method(**kwargs, seed=seed1)
+        rng2 = Method(**kwargs, seed=seed2)
+        assert_equal(rng1.rvs(100), rng2.rvs(100))
+
+    # testing with seed sequence
+    seed = [1, 2, 3]
+    rng1 = Method(**kwargs, seed=seed)
+    rng2 = Method(**kwargs, seed=seed)
+    assert_equal(rng1.rvs(100), rng2.rvs(100))
+
+
+def test_seed_setter():
+    rng1 = TransformedDensityRejection(common_cont_dist, seed=123)
+    rng2 = TransformedDensityRejection(common_cont_dist)
+    rng2.seed = 123
+    assert_equal(rng1.rvs(100), rng2.rvs(100))
+    rng = TransformedDensityRejection(common_cont_dist, seed=123)
+    rvs1 = rng.rvs(100)
+    rng.seed = 123
+    rvs2 = rng.rvs(100)
+    assert_equal(rvs1, rvs2)
+
+
+def test_threading_behaviour():
+    errors = {"err1": None, "err2": None}
+    class Distribution:
+        def __init__(self, pdf_msg):
+            self.pdf_msg = pdf_msg
+        def pdf(self, x):
+            if 49.9 < x < 50.0:
+                raise ValueError(self.pdf_msg)
+            return x
+        def dpdf(self, x):
+            return 1
+
+    def func1():
+        dist = Distribution('foo')
+        rng = TransformedDensityRejection(dist, domain=(10, 100), seed=12)
+        try:
+            rng.rvs(100000)
+        except ValueError as e:
+            errors['err1'] = e.args[0]
+
+    def func2():
+        dist = Distribution('bar')
+        rng = TransformedDensityRejection(dist, domain=(10, 100), seed=2)
+        try:
+            rng.rvs(100000)
+        except ValueError as e:
+            errors['err2'] = e.args[0]
+
+    t1 = threading.Thread(target=func1)
+    t2 = threading.Thread(target=func2)
+
+    t1.start()
+    t2.start()
+
+    t1.join()
+    t2.join()
+
+    assert errors['err1'] == 'foo'
+    assert errors['err2'] == 'bar'
+
+
+@pytest.mark.parametrize("size", [None, 0, (0, ), 1, (10, 3), (2, 3, 4, 5),
+                                  (0, 0), (0, 1)])
+def test_rvs_size(size):
+    # As the `rvs` method is present in the base class and shared between
+    # all the classes, we can just test with one of the methods.
+    rng = TransformedDensityRejection(common_cont_dist)
+    if size is None:
+        assert np.isscalar(rng.rvs(size))
+    else:
+        if np.isscalar(size):
+            size = (size, )
+        assert rng.rvs(size).shape == size
+
+
+class TestTransformedDensityRejection:
+    # Simple Custom Distribution
+    class dist0:
+        def pdf(self, x):
+            return 3/4 * (1-x*x) if abs(x) <= 1 else 0
+        def dpdf(self, x):
+            return 3/4 * (-2*x) if abs(x) <= 1 else 0
+        def cdf(self, x):
+            return 3/4 * (x - x**3/3 + 2/3) if abs(x) <= 1 else 1*(x >= 1)
+
+    # Standard Normal Distribution
+    class dist1:
+        def pdf(self, x):
+            return stats.norm._pdf(x / 0.1)
+        def dpdf(self, x):
+            return -x / 0.01 * stats.norm._pdf(x / 0.1)
+        def cdf(self, x):
+            return stats.norm._cdf(x / 0.1)
+
+    # pdf with piecewise linear function as transformed density
+    # with T = -1/sqrt with shift. Taken from UNU.RAN test suite
+    # (from file t_tdr_ps.c)
+    class dist2:
+        def __init__(self, shift):
+            self.shift = shift
+        def pdf(self, x):
+            x -= self.shift
+            y = 1. / (abs(x) + 1.)
+            return 0.5 * y * y
+        def dpdf(self, x):
+            x -= self.shift
+            y = 1. / (abs(x) + 1.)
+            y = y * y * y
+            return y if (x < 0.) else -y
+        def cdf(self, x):
+            x -= self.shift
+            if x <= 0.:
+                return 0.5 / (1. - x)
+            else:
+                return 1. - 0.5 / (1. + x)
+
+    dists = [dist0(), dist1(), dist2(0.), dist2(10000.)]
+
+    mv0 = [0., 4./15.]
+    mv1 = [0., 0.01]
+    mv2 = [0., np.inf]
+    mv3 = [10000., np.inf]
+    mvs = [mv0, mv1, mv2, mv3]
+
+    @pytest.mark.parametrize("dist, mv_ex",
+                             zip(dists, mvs))
+    def test_basic(self, dist, mv_ex):
+        with suppress_warnings() as sup:
+            # filter the warnings thrown by UNU.RAN
+            sup.filter(RuntimeWarning)
+            rng = TransformedDensityRejection(dist, seed=42)
+        rvs = rng.rvs(100000)
+        mv = rvs.mean(), rvs.var()
+        # test the moments only if the variance is finite
+        if np.isfinite(mv_ex[1]):
+            assert_allclose(mv, mv_ex, rtol=1e-7, atol=1e-1)
+        # Cramer Von Mises test for goodness-of-fit
+        rvs = rng.rvs(500)
+        dist.cdf = np.vectorize(dist.cdf)
+        pval = cramervonmises(rvs, dist.cdf).pvalue
+        assert pval > 0.1
+
+    # PDF 0 everywhere => bad construction points
+    bad_pdfs = [(lambda x: 0, UNURANError, r"50 : bad construction points.")]
+    bad_pdfs += bad_pdfs_common  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("pdf, err, msg", bad_pdfs)
+    def test_bad_pdf(self, pdf, err, msg):
+        class dist:
+            pass
+        dist.pdf = pdf
+        dist.dpdf = lambda x: 1  # an arbitrary dPDF
+        with pytest.raises(err, match=msg):
+            TransformedDensityRejection(dist)
+
+    @pytest.mark.parametrize("dpdf, err, msg", bad_dpdf_common)
+    def test_bad_dpdf(self, dpdf, err, msg):
+        class dist:
+            pass
+        dist.pdf = lambda x: x
+        dist.dpdf = dpdf
+        with pytest.raises(err, match=msg):
+            TransformedDensityRejection(dist, domain=(1, 10))
+
+    # test domains with inf + nan in them. need to write a custom test for
+    # this because not all methods support infinite tails.
+    @pytest.mark.parametrize("domain, err, msg", inf_nan_domains)
+    def test_inf_nan_domains(self, domain, err, msg):
+        with pytest.raises(err, match=msg):
+            TransformedDensityRejection(common_cont_dist, domain=domain)
+
+
+    # TODO: for cpoints < 0, UNU.RAN throws a warning and sets cpoints
+    #       to a default value. This is not consistent with other invalid
+    #       values of cpoints for which it throws errors. Hence, We should
+    #       validate this parameter ourself.
+    @pytest.mark.parametrize("cpoints", [0, 0.1])
+    def test_bad_cpoints_scalar(self, cpoints):
+        with pytest.raises(UNURANError, match=r"50 : bad construction "
+                                              r"points."):
+            TransformedDensityRejection(common_cont_dist, cpoints=cpoints)
+
+    def test_bad_cpoints_array(self):
+        # empty array
+        cpoints = []
+        with pytest.raises(ValueError, match=r"`cpoints` must either be a "
+                                             r"scalar or a non-empty array."):
+            TransformedDensityRejection(common_cont_dist, cpoints=cpoints)
+
+        # cpoints not monotonically increasing
+        cpoints = [1, 1, 1, 1, 1, 1]
+        with pytest.warns(RuntimeWarning, match=r"33 : starting points not "
+                                                r"strictly monotonically "
+                                                r"increasing"):
+            TransformedDensityRejection(common_cont_dist, cpoints=cpoints)
+
+        # cpoints containing nans
+        cpoints = [np.nan, np.nan, np.nan]
+        with pytest.raises(UNURANError, match=r"50 : bad construction "
+                                               r"points."):
+            TransformedDensityRejection(common_cont_dist, cpoints=cpoints)
+
+        # cpoints out of domain
+        cpoints = [-10, 10]
+        with pytest.warns(RuntimeWarning, match=r"50 : starting point out of "
+                                                r"domain"):
+            TransformedDensityRejection(common_cont_dist, domain=(-3, 3),
+                                        cpoints=cpoints)
+
+    def test_bad_c(self):
+        # c < -0.5 => Not Implemented Error
+        msg = r"33 : c < -0.5 not implemented yet"
+        with pytest.raises(UNURANError, match=msg):
+            TransformedDensityRejection(common_cont_dist, c=-1.)
+        # -0.5 < c < 0. => Warning: Not recommended. Using default
+        msg = (r"33 : -0.5 < c < 0 not recommended. using c = -0.5 "
+                r"instead.")
+        with pytest.warns(RuntimeWarning, match=msg):
+            TransformedDensityRejection(common_cont_dist, c=-0.1)
+        # c > 0. => Warning: Using default
+        msg = r"33 : c > 0"
+        with pytest.warns(RuntimeWarning, match=msg):
+            TransformedDensityRejection(common_cont_dist, c=1.)
+        # nan c
+        msg = r"`c` must be a non-nan value."
+        with pytest.raises(ValueError, match=msg):
+            TransformedDensityRejection(common_cont_dist, c=np.nan)
+
+    def test_bad_variant(self):
+        msg = r"Invalid option for the `variant`"
+        with pytest.raises(ValueError, match=msg):
+            TransformedDensityRejection(common_cont_dist, variant='foo')
+
+    u = [np.linspace(0, 1, num=1000), [], [[]], [np.nan],
+         [-np.inf, np.nan, np.inf], 0,
+         [[np.nan, 0.5, 0.1], [0.2, 0.4, np.inf], [-2, 3, 4]]]
+
+    @pytest.mark.parametrize("u", u)
+    def test_ppf_hat(self, u):
+        # Increase the `max_sqhratio` so the ppf_hat is more accurate.
+        rng = TransformedDensityRejection(common_cont_dist,
+                                          max_sqhratio=0.9999,
+                                          max_intervals=10000)
+        # Older versions of NumPy throw RuntimeWarnings for comparisons with nan.
+        with suppress_warnings() as sup:
+            sup.filter(RuntimeWarning, "invalid value encountered in greater")
+            sup.filter(RuntimeWarning, "invalid value encountered in "
+                                       "greater_equal")
+            sup.filter(RuntimeWarning, "invalid value encountered in less")
+            sup.filter(RuntimeWarning, "invalid value encountered in "
+                                       "less_equal")
+            res = rng.ppf_hat(u)
+            expected = stats.norm.ppf(u)
+        assert_allclose(res, expected, rtol=1e-3, atol=1e-5)
+        assert res.shape == expected.shape
+
+    def test_bad_dist(self):
+        # Empty distribution
+        class dist:
+            ...
+        msg = r"`pdf` required but not found."
+        with pytest.raises(ValueError, match=msg):
+            rng = TransformedDensityRejection(dist)
+        # dPDF not present in dist
+        class dist:
+            pdf = lambda x: 1-x*x
+        msg = r"`dpdf` required but not found."
+        with pytest.raises(ValueError, match=msg):
+            rng = TransformedDensityRejection(dist)
+
+
+class TestDiscreteAliasUrn:
+    # DAU fails on these probably because of large domains and small
+    # computation errors in PMF. Mean/SD match but chi-squared test fails.
+    basic_fail_dists = {
+        'nchypergeom_fisher',  # numerical erros on tails
+        'nchypergeom_wallenius',  # numerical erros on tails
+        'randint'  # fails on 32.but ubuntu
+    }
+
+    @pytest.mark.parametrize("distname, params", distdiscrete)
+    def test_basic(self, distname, params):
+        if distname in self.basic_fail_dists:
+            msg = ("DAU fails on these probably because of large domains "
+                   "and small computation errors in PMF.")
+            pytest.skip(msg)
+        if not isinstance(distname, str):
+            dist = distname
+        else:
+            dist = getattr(stats, distname)
+        dist = dist(*params)
+        domain = dist.support()
+        if not np.isfinite(domain[1] - domain[0]):
+            # DAU only works with finite domain. So, skip the distributions
+            # with infinite tails.
+            pytest.skip("DAU only works with a finite domain.")
+        k = np.arange(domain[0], domain[1]+1)
+        pv = dist.pmf(k)
+        mv_ex = dist.stats('mv')
+        rng = DiscreteAliasUrn(pv, domain=domain, seed=42)
+        rvs = rng.rvs(100000)
+        # test if the first few moments match
+        mv = rvs.mean(), rvs.var()
+        assert_allclose(mv, mv_ex, rtol=1e-3, atol=1e-1)
+        # correct for some numerical errors
+        pv = pv / pv.sum()
+        # chi-squared test for goodness-of-fit
+        obs_freqs = np.zeros_like(pv)
+        _, freqs = np.unique(rvs, return_counts=True)
+        freqs = freqs / freqs.sum()
+        obs_freqs[:freqs.size] = freqs
+        pval = chisquare(obs_freqs, pv).pvalue
+        assert pval > 0.1
+
+    # Can't use bad_pmf_common here as we evaluate PMF early on to avoid
+    # unhelpful errors from UNU.RAN.
+    bad_pmf = [
+        # inf returned
+        (lambda x: np.inf, ValueError,
+         r"must contain only finite / non-nan values"),
+        # nan returned
+        (lambda x: np.nan, ValueError,
+         r"must contain only finite / non-nan values"),
+        # all zeros
+        (lambda x: 0.0, ValueError,
+         r"must contain at least one non-zero value"),
+        # Undefined name inside the function
+        (lambda x: foo, NameError,  # type: ignore[name-defined]
+         r"name 'foo' is not defined"),
+        # Returning wrong type.
+        (lambda x: [], ValueError,
+         r"setting an array element with a sequence."),
+        # probabilities < 0
+        (lambda x: -x, UNURANError,
+         r"50 : probability < 0"),
+        # signature of PMF wrong
+        (lambda: 1.0, TypeError,
+         r"takes 0 positional arguments but 1 was given")
+    ]
+
+    @pytest.mark.parametrize("pmf, err, msg", bad_pmf)
+    def test_bad_pmf(self, pmf, err, msg):
+        class dist:
+            pass
+        dist.pmf = pmf
+        with pytest.raises(err, match=msg):
+            DiscreteAliasUrn(dist=dist, domain=(1, 10))
+
+    @pytest.mark.parametrize("pv", [[0.18, 0.02, 0.8],
+                                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]])
+    def test_sampling_with_pv(self, pv):
+        pv = np.asarray(pv, dtype=np.float64)
+        rng = DiscreteAliasUrn(pv, seed=123)
+        rvs = rng.rvs(100_000)
+        pv = pv / pv.sum()
+        variates = np.arange(0, len(pv))
+        # test if the first few moments match
+        m_expected = np.average(variates, weights=pv)
+        v_expected = np.average((variates - m_expected) ** 2, weights=pv)
+        mv_expected = m_expected, v_expected
+        mv = rvs.mean(), rvs.var()
+        assert_allclose(mv, mv_expected, atol=1e-2)
+        # chi-squared test for goodness-of-fit
+        _, freqs = np.unique(rvs, return_counts=True)
+        freqs = freqs / freqs.sum()
+        obs_freqs = np.zeros_like(pv)
+        obs_freqs[: freqs.size] = freqs
+        pval = chisquare(obs_freqs, pv).pvalue
+        assert pval > 0.1
+
+    @pytest.mark.parametrize("pv, msg", bad_pv_common)
+    def test_bad_pv(self, pv, msg):
+        with pytest.raises(ValueError, match=msg):
+            DiscreteAliasUrn(pv)
+
+    # DAU doesn't support infinite tails. So, it should throw an error when
+    # inf is present in the domain.
+    inf_domain = [(-np.inf, np.inf), (np.inf, np.inf), (-np.inf, -np.inf),
+                  (0, np.inf), (-np.inf, 0)]
+
+    @pytest.mark.parametrize("domain", inf_domain)
+    def test_inf_domain(self, domain):
+        with pytest.raises(ValueError, match=r"must be finite"):
+            DiscreteAliasUrn(dist=common_discr_dist, domain=domain,
+                             params=common_discr_dist.params)
+
+    def test_bad_urn_factor(self):
+        with pytest.warns(RuntimeWarning, match=r"relative urn size < 1."):
+            DiscreteAliasUrn([0.5, 0.5], urn_factor=-1)
+
+    def test_bad_args(self):
+        msg = (r"Either a `pv` or a `dist` object with a PMF method "
+               r"required but none given.")
+        with pytest.raises(ValueError, match=msg):
+            DiscreteAliasUrn()
+
+        msg = r"`domain` must be provided if `pv` is not available"
+        with pytest.raises(ValueError, match=msg):
+            DiscreteAliasUrn(dist=common_discr_dist,
+                             params=common_discr_dist.params)
+
+    def test_bad_dist(self):
+        # Empty distribution
+        class dist:
+            ...
+        msg = r"`pmf` required but not found"
+              # `pmf` required but not found.
+        with pytest.raises(ValueError, match=msg):
+            DiscreteAliasUrn(dist=dist, domain=(0, 10))


### PR DESCRIPTION
#### Reference issue

scipy/scipy#14215

#### What does this implement/fix?

scipy/scipy#14215 has memory leaks due to non-local returns. This PR eliminates the problem by using the MessageStream API (originally used in Qhull to handle errors occurring in `qhull` C API).

One of the downsides of this approach is that UNU.RAN uses a global `FILE *` stream which makes it thread-unsafe to use those streams without first acquiring a lock. To expound on the problem, we have to call [`unur_set_stream`](http://statmath.wu.ac.at/software/unuran/doc/unuran.html#funct_003aunur_005fset_005fstream) under a lock otherwise some other thread could change the global `FILE *` variable and all the errors will be redirected to that wrong file. This makes things fairly complex and at this point, I can't tell by myself if something like this is acceptable or an alternate approach should be used. This is quite an adventure in the uncharted lands for me :) This kind of thing has been done previously in Qhull by @pv. If you could spare some time, I would really appreciate your help on this @pv!

Another problem is that because I can't do non-local return in the thunks when an error has occurred in the callback, I have to wait until UNU.RAN's function evaluation has completed and then check with `PyErr_Occured()` if an error has occurred. I am not sure if this is conventional so let me know what you think...

#### Additional information

@rgommers @mckib2 Whenever you are free, can you please take a look at this and review/verify if this approach is correct? If not, is there (yet) another way in which one can deal with this problem? Anyways, let me know your thoughts on this!

Once scipy/scipy#14328 is merged, I have verified locally that `valgrind` reports no memory leaks for both `numpy < 1.19` and `numpy >= 1.19`.

With NumPy < 1.19:

```none
==44175== LEAK SUMMARY:
==44175==    definitely lost: 1,128 bytes in 11 blocks
==44175==    indirectly lost: 0 bytes in 0 blocks
==44175==      possibly lost: 195,264 bytes in 124 blocks
==44175==    still reachable: 3,258,070 bytes in 2,112 blocks
==44175==         suppressed: 0 bytes in 0 blocks
```

With NumPy >= 1.19:

```none
==44181== LEAK SUMMARY:
==44181==    definitely lost: 1,128 bytes in 11 blocks
==44181==    indirectly lost: 0 bytes in 0 blocks
==44181==      possibly lost: 172,983 bytes in 125 blocks
==44181==    still reachable: 3,533,089 bytes in 2,198 blocks
==44181==         suppressed: 0 bytes in 0 blocks
```

The `1128` lost bytes are inside `dlopen.c` library and not UNU.RAN.