### PR TITLE
MAINT: stats: refactor t distribution _stats method

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2318,38 +2318,54 @@ def test_t_entropy():
 
 @pytest.mark.parametrize("methname", ["pdf", "logpdf", "cdf",
                                       "ppf", "sf", "isf"])
-@pytest.mark.parametrize("df", [np.inf, [[np.inf, 1.], [2., np.inf]]])
-@pytest.mark.parametrize("x", [0.5, [0.5, 0.7]])
-def test_t_inf_df(methname, df, x):
-    t_dist = stats.t(df, loc=3, scale=1)
+def test_t_inf_df(methname):
+    t_dist = stats.t(df=np.inf, loc=3, scale=1)
     norm_dist = stats.norm(loc=3, scale=1)
     t_meth = getattr(t_dist, methname)
     norm_meth = getattr(norm_dist, methname)
+    assert_equal(t_meth(0.5), norm_meth(0.5))
+    # diagonal entries (df[0][0], df[1][1]) infinite.
+    df = [[np.inf, 1.],
+          [2., np.inf]]
+    t_dist = stats.t(df=df, loc=3, scale=1)
+    norm_dist = stats.norm(loc=3, scale=1)
+    t_meth = getattr(t_dist, methname)
+    norm_meth = getattr(norm_dist, methname)
+    res = t_meth([0.5, 0.7])
+    # [0.5, 0.7] broadcasts to: [[0.5, 0.7],  => res[0][0] = norm_meth(0.5)
+    #                            [0.5, 0.7]]  => res[1][1] = norm_meth(0.7)
+    assert_equal(res[0][0], norm_meth(0.5))
+    assert_equal(res[1][1], norm_meth(0.7))
 
-    res = np.diag(t_meth(x)) if np.ndim(df) else t_meth(x)
-    reference = norm_meth(x)
-    assert_equal(res, reference)
 
 def test_t_inf_df_stats_entropy():
     assert_equal(stats.t.stats(df=np.inf, loc=3, scale=1),
                  stats.norm.stats(loc=3, scale=1))
     assert_equal(stats.t.entropy(df=np.inf, loc=3, scale=1),
                  stats.norm.entropy(loc=3, scale=1))
-    t_dist = stats.t(df=[[np.inf, 1.], [2., np.inf]],
-                     loc=3, scale=1)
+    # diagonal entries (df[0][0], df[1][1]) infinite.
+    df = [[np.inf, 1.],
+          [2., np.inf]]
+    t_dist = stats.t(df=df, loc=3, scale=1)
     norm_dist = stats.norm(loc=3, scale=1)
     res_stats = t_dist.stats('mvsk')
     res_entropy = t_dist.entropy()
+    # `res_stats`` is an tuple (mu, mu2, g1, g2). Verify that each of these
+    # moments agree with the norma distribution for res[0][0] and res[1][1].
     assert_equal([res_stats[i][0][0] for i in range(4)],
                  norm_dist.stats('mvsk'))
     assert_equal([res_stats[i][1][1] for i in range(4)],
                  norm_dist.stats('mvsk'))
+    # non-diagonal entries must match the t distribution.
     assert_equal([res_stats[i][0][1] for i in range(4)],
                  stats.t.stats(df=1, loc=3, moments='mvsk'))
     assert_equal([res_stats[i][1][0] for i in range(4)],
                  stats.t.stats(df=2, loc=3, moments='mvsk'))
+    # verify that the diagonal entries of `res_entropy` matches the normal
+    # distribution.
     assert_equal(res_entropy[0][0], norm_dist.entropy())
     assert_equal(res_entropy[1][1], norm_dist.entropy())
+    # non-diagonal entries must match the t distribution.
     assert_equal(res_entropy[0][1], stats.t.entropy(df=1, loc=3))
     assert_equal(res_entropy[1][0], stats.t.entropy(df=2, loc=3))
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2350,8 +2350,8 @@ def test_t_inf_df_stats_entropy():
     norm_dist = stats.norm(loc=3, scale=1)
     res_stats = t_dist.stats('mvsk')
     res_entropy = t_dist.entropy()
-    # `res_stats`` is an tuple (mu, mu2, g1, g2). Verify that each of these
-    # moments agree with the norma distribution for res[0][0] and res[1][1].
+    # `res_stats`` is a tuple (mu, mu2, g1, g2). Verify that each of these
+    # moments agrees with the normal distribution for res[0][0] and res[1][1].
     assert_equal([res_stats[i][0][0] for i in range(4)],
                  norm_dist.stats('mvsk'))
     assert_equal([res_stats[i][1][1] for i in range(4)],

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2318,56 +2318,49 @@ def test_t_entropy():
 
 @pytest.mark.parametrize("methname", ["pdf", "logpdf", "cdf",
                                       "ppf", "sf", "isf"])
-def test_t_inf_df(methname):
-    t_dist = stats.t(df=np.inf, loc=3, scale=1)
+@pytest.mark.parametrize("df_infmask", [[0, 0], [1, 1], [0, 1],
+                                        [[0, 1, 0], [1, 1, 1]],
+                                        [[1, 0], [0, 1]],
+                                        [[0], [1]]])
+def test_t_inf_df(methname, df_infmask):
+    np.random.seed(0)
+    df_infmask = np.asarray(df_infmask, dtype=bool)
+    df = np.random.uniform(0, 10, size=df_infmask.shape)
+    x = np.random.randn(*df_infmask.shape)
+    df[df_infmask] = np.inf
+    t_dist = stats.t(df=df, loc=3, scale=1)
+    t_dist_ref = stats.t(df=df[~df_infmask], loc=3, scale=1)
     norm_dist = stats.norm(loc=3, scale=1)
     t_meth = getattr(t_dist, methname)
+    t_meth_ref = getattr(t_dist_ref, methname)
     norm_meth = getattr(norm_dist, methname)
-    assert_equal(t_meth(0.5), norm_meth(0.5))
-    # diagonal entries (df[0][0], df[1][1]) infinite.
-    df = [[np.inf, 1.],
-          [2., np.inf]]
-    t_dist = stats.t(df=df, loc=3, scale=1)
-    norm_dist = stats.norm(loc=3, scale=1)
-    t_meth = getattr(t_dist, methname)
-    norm_meth = getattr(norm_dist, methname)
-    res = t_meth([0.5, 0.7])
-    # [0.5, 0.7] broadcasts to: [[0.5, 0.7],  => res[0][0] = norm_meth(0.5)
-    #                            [0.5, 0.7]]  => res[1][1] = norm_meth(0.7)
-    assert_equal(res[0][0], norm_meth(0.5))
-    assert_equal(res[1][1], norm_meth(0.7))
+    res = t_meth(x)
+    assert_equal(res[df_infmask], norm_meth(x[df_infmask]))
+    assert_equal(res[~df_infmask], t_meth_ref(x[~df_infmask]))
 
 
-def test_t_inf_df_stats_entropy():
-    assert_equal(stats.t.stats(df=np.inf, loc=3, scale=1),
-                 stats.norm.stats(loc=3, scale=1))
-    assert_equal(stats.t.entropy(df=np.inf, loc=3, scale=1),
-                 stats.norm.entropy(loc=3, scale=1))
-    # diagonal entries (df[0][0], df[1][1]) infinite.
-    df = [[np.inf, 1.],
-          [2., np.inf]]
-    t_dist = stats.t(df=df, loc=3, scale=1)
-    norm_dist = stats.norm(loc=3, scale=1)
-    res_stats = t_dist.stats('mvsk')
-    res_entropy = t_dist.entropy()
-    # `res_stats`` is a tuple (mu, mu2, g1, g2). Verify that each of these
-    # moments agrees with the normal distribution for res[0][0] and res[1][1].
-    assert_equal([res_stats[i][0][0] for i in range(4)],
-                 norm_dist.stats('mvsk'))
-    assert_equal([res_stats[i][1][1] for i in range(4)],
-                 norm_dist.stats('mvsk'))
-    # non-diagonal entries must match the t distribution.
-    assert_equal([res_stats[i][0][1] for i in range(4)],
-                 stats.t.stats(df=1, loc=3, moments='mvsk'))
-    assert_equal([res_stats[i][1][0] for i in range(4)],
-                 stats.t.stats(df=2, loc=3, moments='mvsk'))
-    # verify that the diagonal entries of `res_entropy` matches the normal
-    # distribution.
-    assert_equal(res_entropy[0][0], norm_dist.entropy())
-    assert_equal(res_entropy[1][1], norm_dist.entropy())
-    # non-diagonal entries must match the t distribution.
-    assert_equal(res_entropy[0][1], stats.t.entropy(df=1, loc=3))
-    assert_equal(res_entropy[1][0], stats.t.entropy(df=2, loc=3))
+@pytest.mark.parametrize("df_infmask", [[0, 0], [1, 1], [0, 1],
+                                        [[0, 1, 0], [1, 1, 1]],
+                                        [[1, 0], [0, 1]],
+                                        [[0], [1]]])
+def test_t_inf_df_stats_entropy(df_infmask):
+    np.random.seed(0)
+    df_infmask = np.asarray(df_infmask, dtype=bool)
+    df = np.random.uniform(0, 10, size=df_infmask.shape)
+    df[df_infmask] = np.inf
+    res = stats.t.stats(df=df, loc=3, scale=1, moments='mvsk')
+    res_ex_inf = stats.norm.stats(loc=3, scale=1, moments='mvsk')
+    res_ex_noinf = stats.t.stats(df=df[~df_infmask], loc=3, scale=1,
+                                 moments='mvsk')
+    for i in range(4):
+        assert_equal(res[i][df_infmask], res_ex_inf[i])
+        assert_equal(res[i][~df_infmask], res_ex_noinf[i])
+
+    res = stats.t.entropy(df=df, loc=3, scale=1)
+    res_ex_inf = stats.norm.entropy(loc=3, scale=1)
+    res_ex_noinf = stats.t.entropy(df=df[~df_infmask], loc=3, scale=1)
+    assert_equal(res[df_infmask], res_ex_inf)
+    assert_equal(res[~df_infmask], res_ex_noinf)
 
 
 class TestRvDiscrete:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2318,21 +2318,17 @@ def test_t_entropy():
 
 @pytest.mark.parametrize("methname", ["pdf", "logpdf", "cdf",
                                       "ppf", "sf", "isf"])
-def test_t_inf_df(methname):
-    t_dist = stats.t(df=np.inf, loc=3, scale=1)
+@pytest.mark.parametrize("df", [np.inf, [[np.inf, 1.], [2., np.inf]]])
+@pytest.mark.parametrize("x", [0.5, [0.5, 0.7]])
+def test_t_inf_df(methname, df, x):
+    t_dist = stats.t(df, loc=3, scale=1)
     norm_dist = stats.norm(loc=3, scale=1)
     t_meth = getattr(t_dist, methname)
     norm_meth = getattr(norm_dist, methname)
-    assert_equal(t_meth(0.5), norm_meth(0.5))
-    t_dist = stats.t(df=[[np.inf, 1.], [2., np.inf]],
-                     loc=3, scale=1)
-    norm_dist = stats.norm(loc=3, scale=1)
-    t_meth = getattr(t_dist, methname)
-    norm_meth = getattr(norm_dist, methname)
-    res = t_meth([0.5, 0.7])
-    assert_equal(res[0][0], norm_meth(0.5))
-    assert_equal(res[1][1], norm_meth(0.7))
 
+    res = np.diag(t_meth(x)) if np.ndim(df) else t_meth(x)
+    reference = norm_meth(x)
+    assert_equal(res, reference)
 
 def test_t_inf_df_stats_entropy():
     assert_equal(stats.t.stats(df=np.inf, loc=3, scale=1),


### PR DESCRIPTION
#### Reference issue
scipy/scipy#14781

#### What does this implement/fix?
The `_stats` method was already a bit more complex than it needed to be, so adding another layer of `_lazyselect` pushed it over the edge IMO : ) This converts the logic to `_lazyselect`.

I also refactored `test_t_inf_df` for concision. If you like it, consider something similar for `test_t_inf_df_stats_entropy`. I'm getting a bit confused by the triple indexing.