### PR TITLE
MAINT: stats.variation: remove unused code

### DIFF
--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -1,6 +1,5 @@
 import numpy as np
-from scipy._lib._util import (_nan_allsame, _contains_nan,
-                              normalize_axis_index, _get_nan)
+from scipy._lib._util import _nan_allsame, _contains_nan, normalize_axis_index
 from ._stats_py import _chk_asarray
 from ._axis_nan_policy import _axis_nan_policy_factory
 
@@ -184,7 +183,6 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
     a, axis = _chk_asarray(a, axis)
     axis = normalize_axis_index(axis, ndim=a.ndim)
     n = a.shape[axis]
-    NaN = _get_nan(a)
 
     contains_nan, nan_policy = _contains_nan(a, nan_policy)
     if contains_nan and nan_policy == 'omit':
@@ -199,9 +197,9 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
         else:
             del shp[axis]
         if len(shp) == 0:
-            result = NaN
+            result = np.asarray(np.nan)
         else:
-            result = np.full(shp, fill_value=NaN)
+            result = np.full(shp, fill_value=np.nan)
 
         return result[()]
 
@@ -210,13 +208,11 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
     if ddof == n:
         # Another special case.  Result is either inf or nan.
         std_a = a.std(axis=axis, ddof=0, keepdims=True)
-        result = np.full_like(std_a, fill_value=NaN)
-        sign = np.asarray(np.sign(mean_a))
-        sign[sign == 0] = 1
-        result.flat[std_a.flat > 0] = (sign * np.inf).flat
-        if not keepdims:
-            result = np.squeeze(result, axis=axis)
-        return result[()]
+        result = np.full_like(std_a, fill_value=np.nan)
+        result.flat[std_a.flat > 0] = (np.sign(mean_a) * np.inf).flat
+        if result.shape == ():
+            result = result[()]
+        return result
 
     with np.errstate(divide='ignore', invalid='ignore'):
         std_a = a.std(axis, ddof=ddof, keepdims=True)
@@ -224,5 +220,7 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
 
     if not keepdims:
         result = np.squeeze(result, axis=axis)
+        if result.shape == ():
+            result = result[()]
 
-    return result[()]
+    return result

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -1,91 +1,6 @@
 import numpy as np
-from scipy._lib._util import _nan_allsame, _contains_nan, normalize_axis_index
-from ._stats_py import _chk_asarray
+from scipy._lib._util import _nan_allsame, _get_nan
 from ._axis_nan_policy import _axis_nan_policy_factory
-
-
-def _nanvariation(a, *, axis=0, ddof=0, keepdims=False):
-    """
-    Private version of `variation` that ignores nan.
-
-    `a` must be a numpy array.
-    `axis` is assumed to be normalized, i.e. 0 <= axis < a.ndim.
-    """
-    #
-    # In theory, this should be as simple as something like
-    #     nanstd(a, ddof=ddof, axis=axis, keepdims=keepdims) /
-    #     nanmean(a, axis=axis, keepdims=keepdims)
-    # In practice, annoying issues arise.  Specifically, numpy
-    # generates warnings in certain edge cases that we don't want
-    # to propagate to the user.  Unfortunately, there does not
-    # appear to be a thread-safe way to filter out the warnings,
-    # so we have to do the calculation in a way that doesn't
-    # generate numpy warnings.
-    #
-    # Let N be the number of non-nan inputs in a slice.
-    # Conditions that generate nan:
-    #   * empty input (i.e. N = 0)
-    #   * All non-nan values 0
-    #   * N < ddof
-    #   * N == ddof and the input is constant
-    # Conditions that generate inf:
-    #   * non-constant input and either
-    #       * the mean is 0, or
-    #       * N == ddof
-    #
-    a_isnan = np.isnan(a)
-    all_nan = a_isnan.all(axis=axis, keepdims=True)
-    all_nan_full = np.broadcast_to(all_nan, a.shape)
-    all_zero = (a_isnan | (a == 0)).all(axis=axis, keepdims=True) & ~all_nan
-
-    # ngood is the number of non-nan values in each slice.
-    ngood = (a.shape[axis] -
-             np.expand_dims(np.count_nonzero(a_isnan, axis=axis), axis))
-    # The return value is nan where ddof > ngood.
-    ddof_too_big = ddof > ngood
-    # If ddof == ngood, the return value is nan where the input is constant and
-    # inf otherwise.
-    ddof_equal_n = ddof == ngood
-
-    is_const = _nan_allsame(a, axis=axis, keepdims=True)
-
-    a2 = a.copy()
-    # If an entire slice is nan, `np.nanmean` will generate a warning,
-    # so we replace those nan's with 1.0 before computing the mean.
-    # We'll fix the corresponding output later.
-    a2[all_nan_full] = 1.0
-    mean_a = np.nanmean(a2, axis=axis, keepdims=True)
-
-    # If ddof >= ngood (the number of non-nan values in the slice), `np.nanstd`
-    # will generate a warning, so set all the values in such a slice to 1.0.
-    # We'll fix the corresponding output later.
-    a2[np.broadcast_to(ddof_too_big, a2.shape) | ddof_equal_n] = 1.0
-    with np.errstate(invalid='ignore'):
-        std_a = np.nanstd(a2, axis=axis, ddof=ddof, keepdims=True)
-    del a2
-
-    sum_zero = np.nansum(a, axis=axis, keepdims=True) == 0
-
-    # Where the sum along the axis is 0, replace mean_a with 1.  This avoids
-    # division by zero.  We'll fix the corresponding output later.
-    mean_a[sum_zero] = 1.0
-
-    # Here--finally!--is the calculation of the variation.
-    result = std_a / mean_a
-
-    # Now fix the values that were given fake data to avoid warnings.
-    result[~is_const & sum_zero] = np.inf
-    signed_inf_mask = ~is_const & ddof_equal_n
-    result[signed_inf_mask] = np.sign(mean_a[signed_inf_mask]) * np.inf
-    nan_mask = all_zero | all_nan | ddof_too_big | (ddof_equal_n & is_const)
-    result[nan_mask] = np.nan
-
-    if not keepdims:
-        result = np.squeeze(result, axis=axis)
-        if result.shape == ():
-            result = result[()]
-
-    return result
 
 
 @_axis_nan_policy_factory(
@@ -180,47 +95,31 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
     array([1.05109361, 0.31428986, 0.146483  ])
 
     """
-    a, axis = _chk_asarray(a, axis)
-    axis = normalize_axis_index(axis, ndim=a.ndim)
+    # `nan_policy` and `keepdims` are handled by `_axis_nan_policy`
     n = a.shape[axis]
-
-    contains_nan, nan_policy = _contains_nan(a, nan_policy)
-    if contains_nan and nan_policy == 'omit':
-        return _nanvariation(a, axis=axis, ddof=ddof, keepdims=keepdims)
+    NaN = _get_nan(a)
 
     if a.size == 0 or ddof > n:
         # Handle as a special case to avoid spurious warnings.
         # The return values, if any, are all nan.
-        shp = list(a.shape)
-        if keepdims:
-            shp[axis] = 1
-        else:
-            del shp[axis]
-        if len(shp) == 0:
-            result = np.asarray(np.nan)
-        else:
-            result = np.full(shp, fill_value=np.nan)
-
+        shp = np.asarray(a.shape)
+        shp = np.delete(shp, axis)
+        result = np.full(shp, fill_value=NaN)
         return result[()]
 
-    mean_a = a.mean(axis, keepdims=True)
+    mean_a = a.mean(axis)
 
     if ddof == n:
         # Another special case.  Result is either inf or nan.
-        std_a = a.std(axis=axis, ddof=0, keepdims=True)
-        result = np.full_like(std_a, fill_value=np.nan)
-        result.flat[std_a.flat > 0] = (np.sign(mean_a) * np.inf).flat
-        if result.shape == ():
-            result = result[()]
-        return result
+        std_a = a.std(axis=axis, ddof=0)
+        result = np.full_like(std_a, fill_value=NaN)
+        i = std_a > 0
+        result[i] = np.inf
+        result[i] = np.copysign(result[i], mean_a[i])
+        return result[()]
 
     with np.errstate(divide='ignore', invalid='ignore'):
-        std_a = a.std(axis, ddof=ddof, keepdims=True)
+        std_a = a.std(axis, ddof=ddof)
         result = std_a / mean_a
 
-    if not keepdims:
-        result = np.squeeze(result, axis=axis)
-        if result.shape == ():
-            result = result[()]
-
-    return result
+    return result[()]


### PR DESCRIPTION
#### Reference issue
scipy/scipy#19336

#### What does this implement/fix?
Removes `variation` code no longer needed after application of axis/nan_policy decorator.
